### PR TITLE
Check Spark Max Init and Retry

### DIFF
--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -2,8 +2,8 @@ package frc.robot;
 
 import edu.wpi.first.math.controller.PIDController;
 
-/** This class provides a place for arbitrary but tuned values, like PID values. */
-public final class Calibrations {
+/** This class provides a place for Calibrations: arbitrary but tuned values, like PID values. */
+public final class Cal {
   public static final double PLACEHOLDER_DOUBLE = 0.0;
   public static final int PLACEHOLDER_INT = 0;
 
@@ -52,26 +52,26 @@ public final class Calibrations {
     public static final double AUTO_CLAMP_WAIT_TIME_SECONDS = 0.5;
 
     /** Input degrees, output [0,1] */
-    public static final double DEPLOY_MOTOR_P = Calibrations.PLACEHOLDER_DOUBLE,
-        DEPLOY_MOTOR_I = Calibrations.PLACEHOLDER_DOUBLE,
-        DEPLOY_MOTOR_D = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double DEPLOY_MOTOR_P = Cal.PLACEHOLDER_DOUBLE,
+        DEPLOY_MOTOR_I = Cal.PLACEHOLDER_DOUBLE,
+        DEPLOY_MOTOR_D = Cal.PLACEHOLDER_DOUBLE;
 
     /** Intake positions in degrees */
-    public static final double STARTING_POSITION_DEGREES = Calibrations.PLACEHOLDER_DOUBLE,
-        DEPLOYED_POSITION_DEGREES = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double STARTING_POSITION_DEGREES = Cal.PLACEHOLDER_DOUBLE,
+        DEPLOYED_POSITION_DEGREES = Cal.PLACEHOLDER_DOUBLE;
 
     /** Difference in what the intake absolute encoder says is 0 and what is actually 0 */
-    public static final double ABSOLUTE_ENCODER_OFFSET_DEG = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ABSOLUTE_ENCODER_OFFSET_DEG = Cal.PLACEHOLDER_DOUBLE;
 
     /** Voltage required to hold the intake in the horizontal position */
-    public static final double ARBITRARY_FEED_FORWARD_VOLTS = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ARBITRARY_FEED_FORWARD_VOLTS = Cal.PLACEHOLDER_DOUBLE;
 
     /** Parameters for intake SmartMotion */
     public static final double
-        DEPLOY_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = Calibrations.PLACEHOLDER_DOUBLE,
-        DEPLOY_MAX_VELOCITY_DEG_PER_SECOND = Calibrations.PLACEHOLDER_DOUBLE,
-        DEPLOY_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND = Calibrations.PLACEHOLDER_DOUBLE,
-        DEPLOY_ALLOWED_CLOSED_LOOP_ERROR_DEG = Calibrations.PLACEHOLDER_DOUBLE;
+        DEPLOY_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = Cal.PLACEHOLDER_DOUBLE,
+        DEPLOY_MAX_VELOCITY_DEG_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
+        DEPLOY_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
+        DEPLOY_ALLOWED_CLOSED_LOOP_ERROR_DEG = Cal.PLACEHOLDER_DOUBLE;
 
     /** Threshold for having achieved the desired intake position (in degrees) */
     public static final double POSITION_THRESHOLD_DEGREES = 3.0;
@@ -79,38 +79,36 @@ public final class Calibrations {
 
   public static final class Lift {
     /** Input inches, output [0,1] */
-    public static final double ELEVATOR_P = Calibrations.PLACEHOLDER_DOUBLE,
-        ELEVATOR_I = Calibrations.PLACEHOLDER_DOUBLE,
-        ELEVATOR_D = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ELEVATOR_P = Cal.PLACEHOLDER_DOUBLE,
+        ELEVATOR_I = Cal.PLACEHOLDER_DOUBLE,
+        ELEVATOR_D = Cal.PLACEHOLDER_DOUBLE;
 
     /** Input degrees, output [0,1] */
-    public static final double ARM_P = Calibrations.PLACEHOLDER_DOUBLE,
-        ARM_I = Calibrations.PLACEHOLDER_DOUBLE,
-        ARM_D = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ARM_P = Cal.PLACEHOLDER_DOUBLE,
+        ARM_I = Cal.PLACEHOLDER_DOUBLE,
+        ARM_D = Cal.PLACEHOLDER_DOUBLE;
 
     /** Difference in what the arm absolute encoder says is 0 and what is actually 0 */
-    public static final double ARM_ABSOLUTE_ENCODER_OFFSET_DEG = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ARM_ABSOLUTE_ENCODER_OFFSET_DEG = Cal.PLACEHOLDER_DOUBLE;
 
     /** Voltage required to hold the arm in the horizontal position */
-    public static final double ARBITRARY_ARM_FEED_FORWARD_VOLTS = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ARBITRARY_ARM_FEED_FORWARD_VOLTS = Cal.PLACEHOLDER_DOUBLE;
 
     /** Voltage required to hold the elevator */
-    public static final double ARBITRARY_ELEVATOR_FEED_FORWARD_VOLTS =
-        Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ARBITRARY_ELEVATOR_FEED_FORWARD_VOLTS = Cal.PLACEHOLDER_DOUBLE;
 
     /** Parameters for arm SmartMotion */
-    public static final double
-        ARM_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = Calibrations.PLACEHOLDER_DOUBLE,
-        ARM_MAX_VELOCITY_DEG_PER_SECOND = Calibrations.PLACEHOLDER_DOUBLE,
-        ARM_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND = Calibrations.PLACEHOLDER_DOUBLE,
-        ARM_ALLOWED_CLOSED_LOOP_ERROR_DEG = Calibrations.PLACEHOLDER_DOUBLE;
+    public static final double ARM_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED = Cal.PLACEHOLDER_DOUBLE,
+        ARM_MAX_VELOCITY_DEG_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
+        ARM_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
+        ARM_ALLOWED_CLOSED_LOOP_ERROR_DEG = Cal.PLACEHOLDER_DOUBLE;
 
     /** Parameters for elevator SmartMotion */
     public static final double
-        ELEVATOR_MAX_ACCELERATION_IN_PER_SECOND_SQUARED = Calibrations.PLACEHOLDER_DOUBLE,
-        ELEVATOR_MAX_VELOCITY_IN_PER_SECOND = Calibrations.PLACEHOLDER_DOUBLE,
-        ELEVATOR_MIN_OUTPUT_VELOCITY_IN_PER_SECOND = Calibrations.PLACEHOLDER_DOUBLE,
-        ELEVATOR_ALLOWED_CLOSED_LOOP_ERROR_IN = Calibrations.PLACEHOLDER_DOUBLE;
+        ELEVATOR_MAX_ACCELERATION_IN_PER_SECOND_SQUARED = Cal.PLACEHOLDER_DOUBLE,
+        ELEVATOR_MAX_VELOCITY_IN_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
+        ELEVATOR_MIN_OUTPUT_VELOCITY_IN_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
+        ELEVATOR_ALLOWED_CLOSED_LOOP_ERROR_IN = Cal.PLACEHOLDER_DOUBLE;
   }
 
   public static final class AutoBalance {

--- a/src/main/java/frc/robot/Calibrations.java
+++ b/src/main/java/frc/robot/Calibrations.java
@@ -134,4 +134,6 @@ public final class Calibrations {
      */
     public static final double CHARGE_STATION_DEADBAND_NORM_VELOCITY = 0.05;
   }
+
+  public static final int SPARK_INIT_RETRY_ATTEMPTS = 5;
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -51,13 +51,9 @@ public final class Constants {
     public static final double DRIVING_ENCODER_VELOCITY_FACTOR_METERS_PER_SECOND =
         ((WHEEL_DIAMETER_METERS * Math.PI) / DRIVING_MOTOR_REDUCTION) / 60.0; // meters per second
 
-    public static final double TURNING_ENCODER_POSITION_FACTOR_RADIANS = (2 * Math.PI); // radians
-    public static final double TURNING_ENCODER_VELOCITY_FACTOR_RAD_PER_SEC =
-        (2 * Math.PI) / 60.0; // radians per second
-
     public static final double TURNING_ENCODER_POSITION_PID_MIN_INPUT_RADIANS = 0; // radians
     public static final double TURNING_ENCODER_POSITION_PID_MAX_INPUT_RADIANS =
-        TURNING_ENCODER_POSITION_FACTOR_RADIANS; // radians
+        2 * Math.PI; // radians
 
     public static final IdleMode DRIVING_MOTOR_IDLE_MODE = IdleMode.kBrake;
     public static final IdleMode TURNING_MOTOR_IDLE_MODE = IdleMode.kBrake;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -123,11 +123,7 @@ public final class Constants {
   }
 
   public static final class Intake {
-    /* Scalar for deploy motor encoder from RPM to real degrees per seconds */
-    public static final double DEPLOY_MOTOR_ENCODER_VELOCITY_SCALAR = Constants.PLACEHOLDER_DOUBLE;
-
-    /* Scalar for arm motor encoder from rotations to real degrees */
-    public static final double DEPLOY_MOTOR_ENCODER_SCALAR = Constants.PLACEHOLDER_DOUBLE;
+    public static final double DEPLOY_MOTOR_GEAR_RATIO = Constants.PLACEHOLDER_DOUBLE;
 
     public static final double POSITION_WHEN_HORIZONTAL_DEGREES = 180;
   }

--- a/src/main/java/frc/robot/commands/AutoChargeStationBalance.java
+++ b/src/main/java/frc/robot/commands/AutoChargeStationBalance.java
@@ -4,7 +4,7 @@ import com.ctre.phoenix.sensors.WPI_Pigeon2;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.CommandBase;
-import frc.robot.Calibrations.AutoBalance;
+import frc.robot.Cal.AutoBalance;
 import frc.robot.subsystems.drive.DriveSubsystem;
 
 /**

--- a/src/main/java/frc/robot/commands/AutoChargeStationSequence.java
+++ b/src/main/java/frc/robot/commands/AutoChargeStationSequence.java
@@ -8,7 +8,7 @@ import com.pathplanner.lib.PathConstraints;
 import com.pathplanner.lib.PathPlanner;
 import com.pathplanner.lib.PathPlannerTrajectory;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.robot.Calibrations;
+import frc.robot.Cal;
 import frc.robot.Constants;
 import frc.robot.subsystems.drive.DriveSubsystem;
 
@@ -17,7 +17,7 @@ public class AutoChargeStationSequence extends SequentialCommandGroup {
   private PathPlannerTrajectory traj =
       PathPlanner.loadPath(
           Constants.PLACEHOLDER_STRING,
-          new PathConstraints(Calibrations.PLACEHOLDER_DOUBLE, Calibrations.PLACEHOLDER_DOUBLE));
+          new PathConstraints(Cal.PLACEHOLDER_DOUBLE, Cal.PLACEHOLDER_DOUBLE));
 
   public AutoChargeStationSequence(boolean isFirstPath, DriveSubsystem drive) {
     addCommands(

--- a/src/main/java/frc/robot/commands/AutoScoreAndBalance.java
+++ b/src/main/java/frc/robot/commands/AutoScoreAndBalance.java
@@ -5,7 +5,7 @@ import com.pathplanner.lib.PathPlanner;
 import com.pathplanner.lib.PathPlannerTrajectory;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
-import frc.robot.Calibrations;
+import frc.robot.Cal;
 import frc.robot.Constants;
 import frc.robot.subsystems.Lift;
 import frc.robot.subsystems.drive.DriveSubsystem;
@@ -15,7 +15,7 @@ public class AutoScoreAndBalance extends SequentialCommandGroup {
   private PathPlannerTrajectory traj =
       PathPlanner.loadPath(
           Constants.PLACEHOLDER_STRING,
-          new PathConstraints(Calibrations.PLACEHOLDER_DOUBLE, Calibrations.PLACEHOLDER_DOUBLE));
+          new PathConstraints(Cal.PLACEHOLDER_DOUBLE, Cal.PLACEHOLDER_DOUBLE));
 
   public AutoScoreAndBalance(boolean isFirstPath, Lift lift, DriveSubsystem drive) {
     addCommands(

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -17,7 +17,7 @@ import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj.Solenoid;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Calibrations;
+import frc.robot.Cal;
 import frc.robot.Constants;
 import frc.robot.RobotMap;
 import frc.robot.utils.SparkMaxUtils;
@@ -55,17 +55,17 @@ public class Intake extends SubsystemBase {
    */
   private Optional<Timer> clampTimer = Optional.empty();
 
-  private double intakeDesiredPositionDegrees = Calibrations.Intake.STARTING_POSITION_DEGREES;
+  private double intakeDesiredPositionDegrees = Cal.Intake.STARTING_POSITION_DEGREES;
 
   private final int SMART_MOTION_SLOT = 0;
 
   /** Creates a new Intake. */
   public Intake() {
-    SparkMaxUtils.initWithRetry(this::setUpDeploySpark, Calibrations.SPARK_INIT_RETRY_ATTEMPTS);
-    SparkMaxUtils.initWithRetry(
-        this::setUpIntakeWheelSparks, Calibrations.SPARK_INIT_RETRY_ATTEMPTS);
+    SparkMaxUtils.initWithRetry(this::setUpDeploySpark, Cal.SPARK_INIT_RETRY_ATTEMPTS);
+    SparkMaxUtils.initWithRetry(this::setUpIntakeWheelSparks, Cal.SPARK_INIT_RETRY_ATTEMPTS);
   }
 
+  /** Does all the initialization for the sparks, return true on success */
   boolean setUpIntakeWheelSparks() {
     int errors = 0;
     errors += SparkMaxUtils.check(intakeLeft.restoreFactoryDefaults());
@@ -75,6 +75,7 @@ public class Intake extends SubsystemBase {
     return errors == 0;
   }
 
+  /** Does all the initialization for the spark, return true on success */
   boolean setUpDeploySpark() {
     int errors = 0;
 
@@ -87,27 +88,26 @@ public class Intake extends SubsystemBase {
         SparkMaxUtils.check(
             deployMotorAbsoluteEncoder.setPositionConversionFactor(
                 Constants.REVOLUTIONS_TO_DEGREES));
-    errors += SparkMaxUtils.check(deployMotorPID.setP(Calibrations.Intake.DEPLOY_MOTOR_P));
-    errors += SparkMaxUtils.check(deployMotorPID.setI(Calibrations.Intake.DEPLOY_MOTOR_I));
-    errors += SparkMaxUtils.check(deployMotorPID.setD(Calibrations.Intake.DEPLOY_MOTOR_D));
+    errors += SparkMaxUtils.check(deployMotorPID.setP(Cal.Intake.DEPLOY_MOTOR_P));
+    errors += SparkMaxUtils.check(deployMotorPID.setI(Cal.Intake.DEPLOY_MOTOR_I));
+    errors += SparkMaxUtils.check(deployMotorPID.setD(Cal.Intake.DEPLOY_MOTOR_D));
 
     errors +=
         SparkMaxUtils.check(
             deployMotorPID.setSmartMotionMaxAccel(
-                Calibrations.Intake.DEPLOY_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED,
-                SMART_MOTION_SLOT));
+                Cal.Intake.DEPLOY_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED, SMART_MOTION_SLOT));
     errors +=
         SparkMaxUtils.check(
             deployMotorPID.setSmartMotionMaxVelocity(
-                Calibrations.Intake.DEPLOY_MAX_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT));
+                Cal.Intake.DEPLOY_MAX_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT));
     errors +=
         SparkMaxUtils.check(
             deployMotorPID.setSmartMotionMinOutputVelocity(
-                Calibrations.Intake.DEPLOY_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT));
+                Cal.Intake.DEPLOY_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT));
     errors +=
         SparkMaxUtils.check(
             deployMotorPID.setSmartMotionAllowedClosedLoopError(
-                Calibrations.Intake.DEPLOY_ALLOWED_CLOSED_LOOP_ERROR_DEG, SMART_MOTION_SLOT));
+                Cal.Intake.DEPLOY_ALLOWED_CLOSED_LOOP_ERROR_DEG, SMART_MOTION_SLOT));
 
     return errors == 0;
   }
@@ -116,12 +116,12 @@ public class Intake extends SubsystemBase {
   public void deploy() {
     // Set the desired intake position
     deployMotorPID.setReference(
-        Calibrations.Intake.DEPLOYED_POSITION_DEGREES,
+        Cal.Intake.DEPLOYED_POSITION_DEGREES,
         CANSparkMax.ControlType.kSmartMotion,
         SMART_MOTION_SLOT,
-        Calibrations.Intake.ARBITRARY_FEED_FORWARD_VOLTS * getCosineIntakeAngle(),
+        Cal.Intake.ARBITRARY_FEED_FORWARD_VOLTS * getCosineIntakeAngle(),
         ArbFFUnits.kVoltage);
-    intakeDesiredPositionDegrees = Calibrations.Intake.DEPLOYED_POSITION_DEGREES;
+    intakeDesiredPositionDegrees = Cal.Intake.DEPLOYED_POSITION_DEGREES;
 
     // Set a timer only if we're newly deploying
     // If we have already set a timer, we shouldn't restart the timer
@@ -138,22 +138,22 @@ public class Intake extends SubsystemBase {
 
     // Set the desired intake position
     deployMotorPID.setReference(
-        Calibrations.Intake.STARTING_POSITION_DEGREES,
+        Cal.Intake.STARTING_POSITION_DEGREES,
         CANSparkMax.ControlType.kSmartMotion,
         SMART_MOTION_SLOT,
-        Calibrations.Intake.ARBITRARY_FEED_FORWARD_VOLTS * getCosineIntakeAngle(),
+        Cal.Intake.ARBITRARY_FEED_FORWARD_VOLTS * getCosineIntakeAngle(),
         ArbFFUnits.kVoltage);
-    intakeDesiredPositionDegrees = Calibrations.Intake.STARTING_POSITION_DEGREES;
+    intakeDesiredPositionDegrees = Cal.Intake.STARTING_POSITION_DEGREES;
   }
 
   /** Runs the intake wheels inward */
   public void intakeGamePiece() {
-    intakeLeft.set(Calibrations.Intake.INTAKING_POWER);
+    intakeLeft.set(Cal.Intake.INTAKING_POWER);
   }
 
   /** Runs the intake wheels outward */
   public void ejectGamePiece() {
-    intakeLeft.set(Calibrations.Intake.EJECTION_POWER);
+    intakeLeft.set(Cal.Intake.EJECTION_POWER);
   }
 
   public void stopIntakingGamePiece() {
@@ -176,7 +176,7 @@ public class Intake extends SubsystemBase {
 
   public void initialize() {
     deployMotorEncoder.setPosition(
-        deployMotorAbsoluteEncoder.getPosition() + Calibrations.Intake.ABSOLUTE_ENCODER_OFFSET_DEG);
+        deployMotorAbsoluteEncoder.getPosition() + Cal.Intake.ABSOLUTE_ENCODER_OFFSET_DEG);
   }
 
   /** Returns the cosine of the intake angle in degrees off of the horizontal. */
@@ -189,7 +189,7 @@ public class Intake extends SubsystemBase {
   public void periodic() {
     if (clampTimer.isPresent()) {
       // If present, that means we're deployed or in the process of deploying
-      if (clampTimer.get().hasElapsed(Calibrations.Intake.AUTO_CLAMP_WAIT_TIME_SECONDS)) {
+      if (clampTimer.get().hasElapsed(Cal.Intake.AUTO_CLAMP_WAIT_TIME_SECONDS)) {
         // If the time has elapsed, that means we've deployed enough to clamp
         clampIntake();
       } else {
@@ -203,7 +203,7 @@ public class Intake extends SubsystemBase {
 
     // If the intake has achieved its desired position, then cut power
     if (Math.abs(intakeDesiredPositionDegrees - deployMotorEncoder.getPosition())
-        < Calibrations.Intake.POSITION_THRESHOLD_DEGREES) {
+        < Cal.Intake.POSITION_THRESHOLD_DEGREES) {
       deployMotorPID.setReference(0.0, CANSparkMax.ControlType.kVoltage);
     }
   }

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -18,9 +18,10 @@ import edu.wpi.first.wpilibj.DoubleSolenoid;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj.PneumaticsModuleType;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Calibrations;
+import frc.robot.Cal;
 import frc.robot.Constants;
 import frc.robot.RobotMap;
+import frc.robot.utils.SparkMaxUtils;
 import java.util.TreeMap;
 
 /** Contains code for elevator, arm, and game piece grabber */
@@ -71,63 +72,99 @@ public class Lift extends SubsystemBase {
 
   /** Creates a new Lift */
   public Lift() {
-    elevator.restoreFactoryDefaults();
-
-    // Get positions and degrees of elevator through encoder in inches
-    elevatorEncoder.setPositionConversionFactor(Constants.Lift.ELEVATOR_MOTOR_ENCODER_SCALAR);
-    elevatorEncoder.setVelocityConversionFactor(
-        Constants.Lift.ELEVATOR_MOTOR_ENCODER_VELOCITY_SCALAR);
-
-    // Set PID of Elevator
-    elevatorPID.setP(Calibrations.Lift.ELEVATOR_P);
-    elevatorPID.setI(Calibrations.Lift.ELEVATOR_I);
-    elevatorPID.setD(Calibrations.Lift.ELEVATOR_D);
-    elevatorPID.setSmartMotionMaxAccel(
-        Calibrations.Lift.ELEVATOR_MAX_ACCELERATION_IN_PER_SECOND_SQUARED, SMART_MOTION_SLOT);
-    elevatorPID.setSmartMotionMaxVelocity(
-        Calibrations.Lift.ELEVATOR_MAX_VELOCITY_IN_PER_SECOND, SMART_MOTION_SLOT);
-    elevatorPID.setSmartMotionMinOutputVelocity(
-        Calibrations.Lift.ELEVATOR_MIN_OUTPUT_VELOCITY_IN_PER_SECOND, SMART_MOTION_SLOT);
-    elevatorPID.setSmartMotionAllowedClosedLoopError(
-        Calibrations.Lift.ELEVATOR_ALLOWED_CLOSED_LOOP_ERROR_IN, SMART_MOTION_SLOT);
-
-    arm.restoreFactoryDefaults();
-
-    // Set PID of Arm
-    armPID.setP(Calibrations.Lift.ARM_P);
-    armPID.setI(Calibrations.Lift.ARM_I);
-    armPID.setD(Calibrations.Lift.ARM_D);
-    armPID.setSmartMotionMaxAccel(
-        Calibrations.Lift.ARM_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED, SMART_MOTION_SLOT);
-    armPID.setSmartMotionMaxVelocity(
-        Calibrations.Lift.ARM_MAX_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT);
-    armPID.setSmartMotionMinOutputVelocity(
-        Calibrations.Lift.ARM_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT);
-    armPID.setSmartMotionAllowedClosedLoopError(
-        Calibrations.Lift.ARM_ALLOWED_CLOSED_LOOP_ERROR_DEG, SMART_MOTION_SLOT);
-
-    // Get positions and degrees of arm through encoder in degrees /
-    armEncoder.setPositionConversionFactor(Constants.Lift.ARM_MOTOR_ENCODER_SCALAR);
-    armEncoder.setVelocityConversionFactor(Constants.Lift.ARM_MOTOR_ENCODER_VELOCITY_SCALAR);
-    armAbsoluteEncoder.setPositionConversionFactor(Constants.REVOLUTIONS_TO_DEGREES);
+    SparkMaxUtils.initWithRetry(this::initSparks, Cal.SPARK_INIT_RETRY_ATTEMPTS);
 
     // Map of all LiftPosition with according values
     liftPositionMap = new TreeMap<LiftPosition, Pair<Double, Double>>();
     liftPositionMap.put(
         LiftPosition.GRAB_FROM_INTAKE,
-        new Pair<Double, Double>(Calibrations.PLACEHOLDER_DOUBLE, Calibrations.PLACEHOLDER_DOUBLE));
+        new Pair<Double, Double>(Cal.PLACEHOLDER_DOUBLE, Cal.PLACEHOLDER_DOUBLE));
     liftPositionMap.put(
         LiftPosition.SHELF,
-        new Pair<Double, Double>(Calibrations.PLACEHOLDER_DOUBLE, Calibrations.PLACEHOLDER_DOUBLE));
+        new Pair<Double, Double>(Cal.PLACEHOLDER_DOUBLE, Cal.PLACEHOLDER_DOUBLE));
     liftPositionMap.put(
         LiftPosition.SCORE_MID,
-        new Pair<Double, Double>(Calibrations.PLACEHOLDER_DOUBLE, Calibrations.PLACEHOLDER_DOUBLE));
+        new Pair<Double, Double>(Cal.PLACEHOLDER_DOUBLE, Cal.PLACEHOLDER_DOUBLE));
     liftPositionMap.put(
         LiftPosition.SCORE_HIGH,
-        new Pair<Double, Double>(Calibrations.PLACEHOLDER_DOUBLE, Calibrations.PLACEHOLDER_DOUBLE));
+        new Pair<Double, Double>(Cal.PLACEHOLDER_DOUBLE, Cal.PLACEHOLDER_DOUBLE));
     liftPositionMap.put(
         LiftPosition.STARTING,
-        new Pair<Double, Double>(Calibrations.PLACEHOLDER_DOUBLE, Calibrations.PLACEHOLDER_DOUBLE));
+        new Pair<Double, Double>(Cal.PLACEHOLDER_DOUBLE, Cal.PLACEHOLDER_DOUBLE));
+  }
+
+  /** Does all the initialization for the sparks, return true on success */
+  boolean initSparks() {
+    int errors = 0;
+
+    errors += SparkMaxUtils.check(elevator.restoreFactoryDefaults());
+    errors += SparkMaxUtils.check(arm.restoreFactoryDefaults());
+
+    // Get positions and degrees of elevator through encoder in inches
+    errors +=
+        SparkMaxUtils.check(
+            elevatorEncoder.setPositionConversionFactor(
+                Constants.Lift.ELEVATOR_MOTOR_ENCODER_SCALAR));
+    errors +=
+        SparkMaxUtils.check(
+            elevatorEncoder.setVelocityConversionFactor(
+                Constants.Lift.ELEVATOR_MOTOR_ENCODER_VELOCITY_SCALAR));
+
+    // Set PID of Elevator
+    errors += SparkMaxUtils.check(elevatorPID.setP(Cal.Lift.ELEVATOR_P));
+    errors += SparkMaxUtils.check(elevatorPID.setI(Cal.Lift.ELEVATOR_I));
+    errors += SparkMaxUtils.check(elevatorPID.setD(Cal.Lift.ELEVATOR_D));
+    errors +=
+        SparkMaxUtils.check(
+            elevatorPID.setSmartMotionMaxAccel(
+                Cal.Lift.ELEVATOR_MAX_ACCELERATION_IN_PER_SECOND_SQUARED, SMART_MOTION_SLOT));
+    errors +=
+        SparkMaxUtils.check(
+            elevatorPID.setSmartMotionMaxVelocity(
+                Cal.Lift.ELEVATOR_MAX_VELOCITY_IN_PER_SECOND, SMART_MOTION_SLOT));
+    errors +=
+        SparkMaxUtils.check(
+            elevatorPID.setSmartMotionMinOutputVelocity(
+                Cal.Lift.ELEVATOR_MIN_OUTPUT_VELOCITY_IN_PER_SECOND, SMART_MOTION_SLOT));
+    errors +=
+        SparkMaxUtils.check(
+            elevatorPID.setSmartMotionAllowedClosedLoopError(
+                Cal.Lift.ELEVATOR_ALLOWED_CLOSED_LOOP_ERROR_IN, SMART_MOTION_SLOT));
+
+    // Set PID of Arm
+    errors += SparkMaxUtils.check(armPID.setP(Cal.Lift.ARM_P));
+    errors += SparkMaxUtils.check(armPID.setI(Cal.Lift.ARM_I));
+    errors += SparkMaxUtils.check(armPID.setD(Cal.Lift.ARM_D));
+    errors +=
+        SparkMaxUtils.check(
+            armPID.setSmartMotionMaxAccel(
+                Cal.Lift.ARM_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED, SMART_MOTION_SLOT));
+    errors +=
+        SparkMaxUtils.check(
+            armPID.setSmartMotionMaxVelocity(
+                Cal.Lift.ARM_MAX_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT));
+    errors +=
+        SparkMaxUtils.check(
+            armPID.setSmartMotionMinOutputVelocity(
+                Cal.Lift.ARM_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND, SMART_MOTION_SLOT));
+    errors +=
+        SparkMaxUtils.check(
+            armPID.setSmartMotionAllowedClosedLoopError(
+                Cal.Lift.ARM_ALLOWED_CLOSED_LOOP_ERROR_DEG, SMART_MOTION_SLOT));
+
+    // Get positions and degrees of arm through encoder in degrees
+    errors +=
+        SparkMaxUtils.check(
+            armEncoder.setPositionConversionFactor(Constants.Lift.ARM_MOTOR_ENCODER_SCALAR));
+    errors +=
+        SparkMaxUtils.check(
+            armEncoder.setVelocityConversionFactor(
+                Constants.Lift.ARM_MOTOR_ENCODER_VELOCITY_SCALAR));
+    errors +=
+        SparkMaxUtils.check(
+            armAbsoluteEncoder.setPositionConversionFactor(Constants.REVOLUTIONS_TO_DEGREES));
+
+    return errors == 0;
   }
 
   public void goToPosition(LiftPosition pos) {
@@ -135,13 +172,13 @@ public class Lift extends SubsystemBase {
         liftPositionMap.get(pos).getFirst(),
         CANSparkMax.ControlType.kSmartMotion,
         SMART_MOTION_SLOT,
-        Calibrations.Lift.ARBITRARY_ELEVATOR_FEED_FORWARD_VOLTS,
+        Cal.Lift.ARBITRARY_ELEVATOR_FEED_FORWARD_VOLTS,
         ArbFFUnits.kVoltage);
     armPID.setReference(
         liftPositionMap.get(pos).getSecond(),
         CANSparkMax.ControlType.kSmartMotion,
         SMART_MOTION_SLOT,
-        Calibrations.Lift.ARBITRARY_ARM_FEED_FORWARD_VOLTS * getCosineArmAngle(),
+        Cal.Lift.ARBITRARY_ARM_FEED_FORWARD_VOLTS * getCosineArmAngle(),
         ArbFFUnits.kVoltage);
   }
 
@@ -181,7 +218,7 @@ public class Lift extends SubsystemBase {
   public void initialize() {
     // Set arm encoder position from absolute
     armEncoder.setPosition(
-        armAbsoluteEncoder.getPosition() + Calibrations.Lift.ARM_ABSOLUTE_ENCODER_OFFSET_DEG);
+        armAbsoluteEncoder.getPosition() + Cal.Lift.ARM_ABSOLUTE_ENCODER_OFFSET_DEG);
 
     // Set elevator encoder position from absolute encoders
     double elevatorDutyCycleEncodersDifferenceDegrees =

--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -20,7 +20,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.Calibrations;
+import frc.robot.Cal;
 import frc.robot.Constants;
 import frc.robot.RobotMap;
 
@@ -205,9 +205,8 @@ public class DriveSubsystem extends SubsystemBase {
     double offsetHeadingDegrees = MathUtil.inputModulus(headingDifferenceDegrees, -180, 180);
 
     double desiredRotation =
-        Calibrations.SwerveSubsystem.ROTATE_TO_TARGET_PID_CONTROLLER.calculate(
-                offsetHeadingDegrees, 0.0)
-            + Math.signum(offsetHeadingDegrees) * Calibrations.SwerveSubsystem.ROTATE_TO_TARGET_FF;
+        Cal.SwerveSubsystem.ROTATE_TO_TARGET_PID_CONTROLLER.calculate(offsetHeadingDegrees, 0.0)
+            + Math.signum(offsetHeadingDegrees) * Cal.SwerveSubsystem.ROTATE_TO_TARGET_FF;
 
     drive(x, y, desiredRotation, fieldRelative);
   }
@@ -258,12 +257,12 @@ public class DriveSubsystem extends SubsystemBase {
             traj,
             this::getPose, // Pose supplier
             Constants.SwerveDrive.DRIVE_KINEMATICS, // SwerveDriveKinematics
-            Calibrations.SwerveSubsystem
+            Cal.SwerveSubsystem
                 .PATH_X_CONTROLLER, // X controller. Tune these values for your robot. Leaving them
             // 0 will only use feedforwards.
-            Calibrations.SwerveSubsystem
+            Cal.SwerveSubsystem
                 .PATH_Y_CONTROLLER, // Y controller (usually the same values as X controller)
-            Calibrations.SwerveSubsystem
+            Cal.SwerveSubsystem
                 .PATH_THETA_CONTROLLER, // Rotation controller. Tune these values for your robot.
             // Leaving them 0 will only use feedforwards.
             this::setModuleStates, // Module states consumer
@@ -276,12 +275,10 @@ public class DriveSubsystem extends SubsystemBase {
   @Override
   public void initSendable(SendableBuilder builder) {
     super.initSendable(builder);
-    addChild("X Controller", Calibrations.SwerveSubsystem.PATH_X_CONTROLLER);
-    addChild("Y Controller", Calibrations.SwerveSubsystem.PATH_Y_CONTROLLER);
-    addChild("Theta Controller", Calibrations.SwerveSubsystem.PATH_THETA_CONTROLLER);
-    addChild(
-        "Rotate to target controller",
-        Calibrations.SwerveSubsystem.ROTATE_TO_TARGET_PID_CONTROLLER);
+    addChild("X Controller", Cal.SwerveSubsystem.PATH_X_CONTROLLER);
+    addChild("Y Controller", Cal.SwerveSubsystem.PATH_Y_CONTROLLER);
+    addChild("Theta Controller", Cal.SwerveSubsystem.PATH_THETA_CONTROLLER);
+    addChild("Rotate to target controller", Cal.SwerveSubsystem.ROTATE_TO_TARGET_PID_CONTROLLER);
     addChild("Front Right", frontRight);
     addChild("Front Left", frontLeft);
     addChild("Back Right", rearLeft);

--- a/src/main/java/frc/robot/utils/SparkMaxUtils.java
+++ b/src/main/java/frc/robot/utils/SparkMaxUtils.java
@@ -1,5 +1,6 @@
 package frc.robot.utils;
 
+import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.REVLibError;
 import com.revrobotics.RelativeEncoder;
@@ -17,6 +18,32 @@ public class SparkMaxUtils {
   }
 
   public static class UnitConversions {
+
+    public static REVLibError setDegreesFromGearRatio(
+        AbsoluteEncoder sparkMaxEncoder, double ratio) {
+      double degreesPerRotation = 360.0 / ratio;
+      double degreesPerRotationPerSecond = degreesPerRotation / 60.0;
+      REVLibError error = sparkMaxEncoder.setPositionConversionFactor(degreesPerRotation);
+
+      if (error != REVLibError.kOk) {
+        return error;
+      }
+
+      return sparkMaxEncoder.setVelocityConversionFactor(degreesPerRotationPerSecond);
+    }
+
+    public static REVLibError setRadsFromGearRatio(AbsoluteEncoder sparkMaxEncoder, double ratio) {
+      double radsPerRotation = (2.0 * Math.PI) / ratio;
+      double radsPerRotationPerSecond = radsPerRotation / 60.0;
+      REVLibError error = sparkMaxEncoder.setPositionConversionFactor(radsPerRotation);
+
+      if (error != REVLibError.kOk) {
+        return error;
+      }
+
+      return sparkMaxEncoder.setVelocityConversionFactor(radsPerRotationPerSecond);
+    }
+
     public static REVLibError setDegreesFromGearRatio(
         RelativeEncoder sparkMaxEncoder, double ratio) {
       double degreesPerRotation = 360.0 / ratio;

--- a/src/main/java/frc/robot/utils/SparkMaxUtils.java
+++ b/src/main/java/frc/robot/utils/SparkMaxUtils.java
@@ -1,0 +1,75 @@
+package frc.robot.utils;
+
+import com.revrobotics.CANSparkMax;
+import com.revrobotics.REVLibError;
+import com.revrobotics.RelativeEncoder;
+import java.util.function.BooleanSupplier;
+
+/** Mostly borrowed from 3005 */
+public class SparkMaxUtils {
+
+  /**
+   * @param error API return value
+   * @return
+   */
+  public static int check(REVLibError error) {
+    return error == REVLibError.kOk ? 0 : 1;
+  }
+
+  public static class UnitConversions {
+    public static REVLibError setDegreesFromGearRatio(
+        RelativeEncoder sparkMaxEncoder, double ratio) {
+      double degreesPerRotation = 360.0 / ratio;
+      double degreesPerRotationPerSecond = degreesPerRotation / 60.0;
+      REVLibError error = sparkMaxEncoder.setPositionConversionFactor(degreesPerRotation);
+
+      if (error != REVLibError.kOk) {
+        return error;
+      }
+
+      return sparkMaxEncoder.setVelocityConversionFactor(degreesPerRotationPerSecond);
+    }
+
+    public static REVLibError setRadsFromGearRatio(RelativeEncoder sparkMaxEncoder, double ratio) {
+      double radsPerRotation = (2.0 * Math.PI) / ratio;
+      double radsPerRotationPerSecond = radsPerRotation / 60.0;
+      REVLibError error = sparkMaxEncoder.setPositionConversionFactor(radsPerRotation);
+
+      if (error != REVLibError.kOk) {
+        return error;
+      }
+
+      return sparkMaxEncoder.setVelocityConversionFactor(radsPerRotationPerSecond);
+    }
+  }
+
+  public static String faultWordToString(short faults) {
+    if (faults == 0) {
+      return "";
+    }
+
+    StringBuilder builder = new StringBuilder();
+    int faultsInt = faults;
+    for (int i = 0; i < 16; i++) {
+      if (((1 << i) & faultsInt) != 0) {
+        builder.append(CANSparkMax.FaultID.fromId(i).toString());
+        builder.append(" ");
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Takes a function returning true on success, and tries running it until it succeeds up to the
+   * max retry attempts
+   */
+  public static void initWithRetry(BooleanSupplier initFunction, int maxRetryAttempts) {
+    int numAttempts = 0;
+    while (!initFunction.getAsBoolean()) {
+      numAttempts++;
+      if (numAttempts > maxRetryAttempts) {
+        break;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds some utilities from 3005 for initializing sparks and uses them on initializing sparks in all the subsystems. Additionally, it renames Calibrations to Cal because it's shorter.