### PR TITLE
Avoid intersection by transit through Start

### DIFF
--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -109,6 +109,17 @@ public final class Cal {
         ELEVATOR_MAX_VELOCITY_IN_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
         ELEVATOR_MIN_OUTPUT_VELOCITY_IN_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
         ELEVATOR_ALLOWED_CLOSED_LOOP_ERROR_IN = Cal.PLACEHOLDER_DOUBLE;
+
+    /**
+     * Thresholds for when we consider the lift has reached a position. This is logical (for
+     * considering where the lift can go) but not functional (does not stop arm control or something
+     * when reached). We apply broader thresholds for the Starting position as the lift transits
+     * through this position.
+     */
+    public static final double ELEVATOR_THRESHOLD_INCHES = 0.5,
+        ARM_THRESHOLD_DEGREES = 2.0,
+        ELEVATOR_START_THRESHOLD_INCHES = 1.0,
+        ARM_START_THRESHOLD_DEGREES = 4.0;
   }
 
   public static final class AutoBalance {

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -318,7 +318,9 @@ public class Lift extends SubsystemBase {
     LiftPositionStartRelative latestPositionStartRelative = getRelativeLiftPosition(latestPosition);
     LiftPositionStartRelative desiredPositionStartRelative =
         getRelativeLiftPosition(desiredPosition);
-    if (desiredPositionStartRelative == LiftPositionStartRelative.BELOW_START
+    if (!seeGamePiece()){
+      goToPosition(desiredPosition);
+    } else if (desiredPositionStartRelative == LiftPositionStartRelative.BELOW_START
         && latestPositionStartRelative == LiftPositionStartRelative.ABOVE_START) {
       goToPosition(LiftPosition.STARTING);
     } else if (desiredPositionStartRelative == LiftPositionStartRelative.ABOVE_START

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -318,7 +318,7 @@ public class Lift extends SubsystemBase {
     LiftPositionStartRelative latestPositionStartRelative = getRelativeLiftPosition(latestPosition);
     LiftPositionStartRelative desiredPositionStartRelative =
         getRelativeLiftPosition(desiredPosition);
-    if (!seeGamePiece()){
+    if (!seeGamePiece()) {
       goToPosition(desiredPosition);
     } else if (desiredPositionStartRelative == LiftPositionStartRelative.BELOW_START
         && latestPositionStartRelative == LiftPositionStartRelative.ABOVE_START) {


### PR DESCRIPTION
This PR adds a concept to the Lift of a current and desired Position. It also considers whether positions are above or below the starting position. When moving from above to below or vice versa, the robot will transit through the starting position, which avoids any possibility of self-intersection.