### PR TITLE
Added Soft Limits to Sparks Max for Elevator, Arm, and Intake

### DIFF
--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -77,11 +77,9 @@ public final class Cal {
     /** Margin for having achieved the desired intake position (in degrees) */
     public static final double POSITION_MARGIN_DEGREES = 3.0;
 
-    /** Positive and negative margins for softLimits for SparksMax */
-    public static final float INTAKE_LEFT_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
-        INTAKE_LEFT_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT,
-        INTAKE_RIGHT_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
-        INTAKE_RIGHT_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT;
+    /** Sets the min and max positions that the intake deploy motor will be allowed to reach */
+    public static final float INTAKE_DEPLOY_MOTOR_POSITIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT,
+    INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT;
   }
 
   public static final class Lift {
@@ -117,11 +115,11 @@ public final class Cal {
         ELEVATOR_MIN_OUTPUT_VELOCITY_IN_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
         ELEVATOR_ALLOWED_CLOSED_LOOP_ERROR_IN = Cal.PLACEHOLDER_DOUBLE;
 
-    /** Positive and negative margins for softLimits for SparksMax */
-    public static final float ELEVATOR_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
-        ELEVATOR_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT,
-        ARM_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
-        ARM_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT;
+    /** Sets the min and max positions that the elevator and arm motors will be allowed to reach */
+    public static final float ELEVATOR_POSITIVE_LIMIT_INCHES = PLACEHOLDER_FLOAT,
+        ELEVATOR_NEGATIVE_LIMIT_INCHES = PLACEHOLDER_FLOAT,
+        ARM_POSITIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT,
+        ARM_NEGATIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT;
 
     /**
      * Margin for when we consider the lift has reached a position. This is logical (for considering

--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -79,7 +79,7 @@ public final class Cal {
 
     /** Sets the min and max positions that the intake deploy motor will be allowed to reach */
     public static final float INTAKE_DEPLOY_MOTOR_POSITIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT,
-    INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT;
+        INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT;
   }
 
   public static final class Lift {

--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -6,6 +6,7 @@ import edu.wpi.first.math.controller.PIDController;
 public final class Cal {
   public static final double PLACEHOLDER_DOUBLE = 0.0;
   public static final int PLACEHOLDER_INT = 0;
+  public static final float PLACEHOLDER_FLOAT = 0;
 
   public static final class SwerveModule {
     /** Input meters/second, output [-1,1] */
@@ -73,8 +74,14 @@ public final class Cal {
         DEPLOY_MIN_OUTPUT_VELOCITY_DEG_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
         DEPLOY_ALLOWED_CLOSED_LOOP_ERROR_DEG = Cal.PLACEHOLDER_DOUBLE;
 
-    /** Threshold for having achieved the desired intake position (in degrees) */
-    public static final double POSITION_THRESHOLD_DEGREES = 3.0;
+    /** Margin for having achieved the desired intake position (in degrees) */
+    public static final double POSITION_MARGIN_DEGREES = 3.0;
+
+    /** Positive and negative margins for softLimits for SparksMax */
+    public static final float INTAKE_LEFT_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
+        INTAKE_LEFT_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT,
+        INTAKE_RIGHT_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
+        INTAKE_RIGHT_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT;
   }
 
   public static final class Lift {
@@ -110,16 +117,22 @@ public final class Cal {
         ELEVATOR_MIN_OUTPUT_VELOCITY_IN_PER_SECOND = Cal.PLACEHOLDER_DOUBLE,
         ELEVATOR_ALLOWED_CLOSED_LOOP_ERROR_IN = Cal.PLACEHOLDER_DOUBLE;
 
+    /** Positive and negative margins for softLimits for SparksMax */
+    public static final float ELEVATOR_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
+        ELEVATOR_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT,
+        ARM_POSITIVE_MARGIN = PLACEHOLDER_FLOAT,
+        ARM_NEGATIVE_MARGIN = PLACEHOLDER_FLOAT;
+
     /**
-     * Thresholds for when we consider the lift has reached a position. This is logical (for
-     * considering where the lift can go) but not functional (does not stop arm control or something
-     * when reached). We apply broader thresholds for the Starting position as the lift transits
-     * through this position.
+     * Margin for when we consider the lift has reached a position. This is logical (for considering
+     * where the lift can go) but not functional (does not stop arm control or something when
+     * reached). We apply broader margins for the Starting position as the lift transits through
+     * this position.
      */
-    public static final double ELEVATOR_THRESHOLD_INCHES = 0.5,
-        ARM_THRESHOLD_DEGREES = 2.0,
-        ELEVATOR_START_THRESHOLD_INCHES = 1.0,
-        ARM_START_THRESHOLD_DEGREES = 4.0;
+    public static final double ELEVATOR_MARGIN_INCHES = 0.5,
+        ARM_MARGIN_DEGREES = 2.0,
+        ELEVATOR_START_MARGIN_INCHES = 1.0,
+        ARM_START_MARGIN_DEGREES = 4.0;
   }
 
   public static final class AutoBalance {

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -10,6 +10,7 @@ import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxAbsoluteEncoder.Type;
 import com.revrobotics.SparkMaxPIDController;
+import com.revrobotics.CANSparkMax.SoftLimitDirection;
 import com.revrobotics.SparkMaxPIDController.ArbFFUnits;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.DigitalInput;
@@ -66,17 +67,29 @@ public class Intake extends SubsystemBase {
   }
 
   /** Does all the initialization for the sparks, return true on success */
-  boolean setUpIntakeWheelSparks() {
+  private boolean setUpIntakeWheelSparks() {
     int errors = 0;
     errors += SparkMaxUtils.check(intakeLeft.restoreFactoryDefaults());
 
     errors += SparkMaxUtils.check(intakeRight.restoreFactoryDefaults());
     errors += SparkMaxUtils.check(intakeRight.follow(intakeLeft, true));
+
+    errors += SparkMaxUtils.check(intakeLeft.setSoftLimit(SoftLimitDirection.kForward, Cal.Intake.INTAKE_LEFT_POSITIVE_MARGIN));
+    errors += SparkMaxUtils.check(intakeLeft.enableSoftLimit(SoftLimitDirection.kForward, true));
+    errors += SparkMaxUtils.check(intakeLeft.setSoftLimit(SoftLimitDirection.kReverse, Cal.Intake.INTAKE_LEFT_NEGATIVE_MARGIN));
+    errors += SparkMaxUtils.check(intakeLeft.enableSoftLimit(SoftLimitDirection.kReverse, true));
+
+    errors += SparkMaxUtils.check(intakeRight.setSoftLimit(SoftLimitDirection.kForward, Cal.Intake.INTAKE_RIGHT_POSITIVE_MARGIN));
+    errors += SparkMaxUtils.check(intakeRight.enableSoftLimit(SoftLimitDirection.kForward, true));
+    errors += SparkMaxUtils.check(intakeRight.setSoftLimit(SoftLimitDirection.kReverse, Cal.Intake.INTAKE_RIGHT_NEGATIVE_MARGIN));
+    errors += SparkMaxUtils.check(intakeRight.enableSoftLimit(SoftLimitDirection.kReverse, true));
+
+
     return errors == 0;
   }
 
   /** Does all the initialization for the spark, return true on success */
-  boolean setUpDeploySpark() {
+  private boolean setUpDeploySpark() {
     int errors = 0;
 
     errors += SparkMaxUtils.check(deployMotor.restoreFactoryDefaults());
@@ -216,7 +229,7 @@ public class Intake extends SubsystemBase {
 
     // If the intake has achieved its desired position, then cut power
     if (Math.abs(intakeDesiredPositionDegrees - deployMotorEncoder.getPosition())
-        < Cal.Intake.POSITION_THRESHOLD_DEGREES) {
+        < Cal.Intake.POSITION_MARGIN_DEGREES) {
       deployMotorPID.setReference(0.0, CANSparkMax.ControlType.kVoltage);
     }
   }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -6,11 +6,11 @@ package frc.robot.subsystems;
 
 import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkMax.SoftLimitDirection;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxAbsoluteEncoder.Type;
 import com.revrobotics.SparkMaxPIDController;
-import com.revrobotics.CANSparkMax.SoftLimitDirection;
 import com.revrobotics.SparkMaxPIDController.ArbFFUnits;
 import edu.wpi.first.util.sendable.SendableBuilder;
 import edu.wpi.first.wpilibj.DigitalInput;
@@ -73,18 +73,6 @@ public class Intake extends SubsystemBase {
 
     errors += SparkMaxUtils.check(intakeRight.restoreFactoryDefaults());
     errors += SparkMaxUtils.check(intakeRight.follow(intakeLeft, true));
-
-    errors += SparkMaxUtils.check(intakeLeft.setSoftLimit(SoftLimitDirection.kForward, Cal.Intake.INTAKE_LEFT_POSITIVE_MARGIN));
-    errors += SparkMaxUtils.check(intakeLeft.enableSoftLimit(SoftLimitDirection.kForward, true));
-    errors += SparkMaxUtils.check(intakeLeft.setSoftLimit(SoftLimitDirection.kReverse, Cal.Intake.INTAKE_LEFT_NEGATIVE_MARGIN));
-    errors += SparkMaxUtils.check(intakeLeft.enableSoftLimit(SoftLimitDirection.kReverse, true));
-
-    errors += SparkMaxUtils.check(intakeRight.setSoftLimit(SoftLimitDirection.kForward, Cal.Intake.INTAKE_RIGHT_POSITIVE_MARGIN));
-    errors += SparkMaxUtils.check(intakeRight.enableSoftLimit(SoftLimitDirection.kForward, true));
-    errors += SparkMaxUtils.check(intakeRight.setSoftLimit(SoftLimitDirection.kReverse, Cal.Intake.INTAKE_RIGHT_NEGATIVE_MARGIN));
-    errors += SparkMaxUtils.check(intakeRight.enableSoftLimit(SoftLimitDirection.kReverse, true));
-
-
     return errors == 0;
   }
 
@@ -121,6 +109,22 @@ public class Intake extends SubsystemBase {
         SparkMaxUtils.check(
             deployMotorPID.setSmartMotionAllowedClosedLoopError(
                 Cal.Intake.DEPLOY_ALLOWED_CLOSED_LOOP_ERROR_DEG, SMART_MOTION_SLOT));
+
+    errors +=
+        SparkMaxUtils.check(
+            deployMotor.setSoftLimit(
+                SoftLimitDirection.kForward, Cal.Intake.INTAKE_DEPLOY_MOTOR_POSITIVE_LIMIT_DEGREES));
+    errors +=
+        SparkMaxUtils.check(
+            deployMotor.enableSoftLimit(SoftLimitDirection.kForward, true));
+
+    errors +=
+        SparkMaxUtils.check(
+            deployMotor.setSoftLimit(
+                SoftLimitDirection.kReverse, Cal.Intake.INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES));
+    errors +=
+        SparkMaxUtils.check(
+            deployMotor.enableSoftLimit(SoftLimitDirection.kReverse, true));
 
     return errors == 0;
   }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -113,18 +113,16 @@ public class Intake extends SubsystemBase {
     errors +=
         SparkMaxUtils.check(
             deployMotor.setSoftLimit(
-                SoftLimitDirection.kForward, Cal.Intake.INTAKE_DEPLOY_MOTOR_POSITIVE_LIMIT_DEGREES));
-    errors +=
-        SparkMaxUtils.check(
-            deployMotor.enableSoftLimit(SoftLimitDirection.kForward, true));
+                SoftLimitDirection.kForward,
+                Cal.Intake.INTAKE_DEPLOY_MOTOR_POSITIVE_LIMIT_DEGREES));
+    errors += SparkMaxUtils.check(deployMotor.enableSoftLimit(SoftLimitDirection.kForward, true));
 
     errors +=
         SparkMaxUtils.check(
             deployMotor.setSoftLimit(
-                SoftLimitDirection.kReverse, Cal.Intake.INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES));
-    errors +=
-        SparkMaxUtils.check(
-            deployMotor.enableSoftLimit(SoftLimitDirection.kReverse, true));
+                SoftLimitDirection.kReverse,
+                Cal.Intake.INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES));
+    errors += SparkMaxUtils.check(deployMotor.enableSoftLimit(SoftLimitDirection.kReverse, true));
 
     return errors == 0;
   }

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -6,6 +6,7 @@ package frc.robot.subsystems;
 
 import com.revrobotics.AbsoluteEncoder;
 import com.revrobotics.CANSparkMax;
+import com.revrobotics.CANSparkMax.SoftLimitDirection;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.SparkMaxAbsoluteEncoder.Type;
@@ -104,7 +105,7 @@ public class Lift extends SubsystemBase {
   }
 
   /** Does all the initialization for the sparks, return true on success */
-  boolean initSparks() {
+  private boolean initSparks() {
     int errors = 0;
 
     errors += SparkMaxUtils.check(elevator.restoreFactoryDefaults());
@@ -173,6 +174,24 @@ public class Lift extends SubsystemBase {
     errors +=
         SparkMaxUtils.check(
             armAbsoluteEncoder.setPositionConversionFactor(Constants.REVOLUTIONS_TO_DEGREES));
+
+    errors +=
+        SparkMaxUtils.check(
+            elevator.setSoftLimit(SoftLimitDirection.kForward, Cal.Lift.ELEVATOR_POSITIVE_MARGIN));
+    errors += SparkMaxUtils.check(elevator.enableSoftLimit(SoftLimitDirection.kForward, true));
+    errors +=
+        SparkMaxUtils.check(
+            elevator.setSoftLimit(SoftLimitDirection.kReverse, Cal.Lift.ELEVATOR_NEGATIVE_MARGIN));
+    errors += SparkMaxUtils.check(elevator.enableSoftLimit(SoftLimitDirection.kReverse, true));
+
+    errors +=
+        SparkMaxUtils.check(
+            arm.setSoftLimit(SoftLimitDirection.kForward, Cal.Lift.ARM_POSITIVE_MARGIN));
+    errors += SparkMaxUtils.check(arm.enableSoftLimit(SoftLimitDirection.kForward, true));
+    errors +=
+        SparkMaxUtils.check(
+            arm.setSoftLimit(SoftLimitDirection.kReverse, Cal.Lift.ARM_NEGATIVE_MARGIN));
+    errors += SparkMaxUtils.check(arm.enableSoftLimit(SoftLimitDirection.kReverse, true));
 
     return errors == 0;
   }
@@ -264,12 +283,12 @@ public class Lift extends SubsystemBase {
   private boolean atPosition(LiftPosition positionToCheck) {
     double armThresholdDegrees =
         positionToCheck == LiftPosition.STARTING
-            ? Cal.Lift.ARM_START_THRESHOLD_DEGREES
-            : Cal.Lift.ARM_THRESHOLD_DEGREES;
+            ? Cal.Lift.ARM_START_MARGIN_DEGREES
+            : Cal.Lift.ARM_MARGIN_DEGREES;
     double elevatorThresholdInches =
         positionToCheck == LiftPosition.STARTING
-            ? Cal.Lift.ELEVATOR_START_THRESHOLD_INCHES
-            : Cal.Lift.ELEVATOR_THRESHOLD_INCHES;
+            ? Cal.Lift.ELEVATOR_START_MARGIN_INCHES
+            : Cal.Lift.ELEVATOR_MARGIN_INCHES;
     double elevatorPositionToCheckInches = liftPositionMap.get(positionToCheck).getFirst();
     double armPositionToCheckDegrees = liftPositionMap.get(positionToCheck).getSecond();
     double elevatorPositionInches = elevatorEncoder.getPosition();

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -177,11 +177,13 @@ public class Lift extends SubsystemBase {
 
     errors +=
         SparkMaxUtils.check(
-            elevator.setSoftLimit(SoftLimitDirection.kForward, Cal.Lift.ELEVATOR_POSITIVE_LIMIT_INCHES));
+            elevator.setSoftLimit(
+                SoftLimitDirection.kForward, Cal.Lift.ELEVATOR_POSITIVE_LIMIT_INCHES));
     errors += SparkMaxUtils.check(elevator.enableSoftLimit(SoftLimitDirection.kForward, true));
     errors +=
         SparkMaxUtils.check(
-            elevator.setSoftLimit(SoftLimitDirection.kReverse, Cal.Lift.ELEVATOR_NEGATIVE_LIMIT_INCHES));
+            elevator.setSoftLimit(
+                SoftLimitDirection.kReverse, Cal.Lift.ELEVATOR_NEGATIVE_LIMIT_INCHES));
     errors += SparkMaxUtils.check(elevator.enableSoftLimit(SoftLimitDirection.kReverse, true));
 
     errors +=

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -177,20 +177,20 @@ public class Lift extends SubsystemBase {
 
     errors +=
         SparkMaxUtils.check(
-            elevator.setSoftLimit(SoftLimitDirection.kForward, Cal.Lift.ELEVATOR_POSITIVE_MARGIN));
+            elevator.setSoftLimit(SoftLimitDirection.kForward, Cal.Lift.ELEVATOR_POSITIVE_LIMIT_INCHES));
     errors += SparkMaxUtils.check(elevator.enableSoftLimit(SoftLimitDirection.kForward, true));
     errors +=
         SparkMaxUtils.check(
-            elevator.setSoftLimit(SoftLimitDirection.kReverse, Cal.Lift.ELEVATOR_NEGATIVE_MARGIN));
+            elevator.setSoftLimit(SoftLimitDirection.kReverse, Cal.Lift.ELEVATOR_NEGATIVE_LIMIT_INCHES));
     errors += SparkMaxUtils.check(elevator.enableSoftLimit(SoftLimitDirection.kReverse, true));
 
     errors +=
         SparkMaxUtils.check(
-            arm.setSoftLimit(SoftLimitDirection.kForward, Cal.Lift.ARM_POSITIVE_MARGIN));
+            arm.setSoftLimit(SoftLimitDirection.kForward, Cal.Lift.ARM_POSITIVE_LIMIT_DEGREES));
     errors += SparkMaxUtils.check(arm.enableSoftLimit(SoftLimitDirection.kForward, true));
     errors +=
         SparkMaxUtils.check(
-            arm.setSoftLimit(SoftLimitDirection.kReverse, Cal.Lift.ARM_NEGATIVE_MARGIN));
+            arm.setSoftLimit(SoftLimitDirection.kReverse, Cal.Lift.ARM_NEGATIVE_LIMIT_DEGREES));
     errors += SparkMaxUtils.check(arm.enableSoftLimit(SoftLimitDirection.kReverse, true));
 
     return errors == 0;


### PR DESCRIPTION
* Set soft limits for both directions (forward and reverse) for elevator, arm, and intake
* Enabled soft limits for both directions (forward and reverse) for elevator, arm, and intake
* Made placeholder floats in Cal for the margins for soft limits