### PR TITLE
Added intake command sequence

### DIFF
--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -82,7 +82,7 @@ public final class Cal {
         INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT;
     
     /** Time for the intake to unclamp, in seconds */
-    public static final double UNCLAMP_TIME_SECONDS = PLACEHOLDER_DOUBLE;
+    public static final double UNCLAMP_TIME_SECONDS = 0.2;
   }
 
   public static final class Lift {

--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -80,6 +80,9 @@ public final class Cal {
     /** Sets the min and max positions that the intake deploy motor will be allowed to reach */
     public static final float INTAKE_DEPLOY_MOTOR_POSITIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT,
         INTAKE_DEPLOY_MOTOR_NEGATIVE_LIMIT_DEGREES = PLACEHOLDER_FLOAT;
+    
+    /** Time for the intake to unclamp, in seconds */
+    public static final double UNCLAMP_TIME_SECONDS = PLACEHOLDER_DOUBLE;
   }
 
   public static final class Lift {
@@ -144,6 +147,9 @@ public final class Cal {
     /** Zone where the grabber must be closed, in degrees. Bottom is closer to intake. */
     public static final double GRABBER_CLOSED_ZONE_BOTTOM_DEGREES = PLACEHOLDER_DOUBLE,
         GRABBER_CLOSED_ZONE_TOP_DEGREES = PLACEHOLDER_DOUBLE;
+    
+    /** Time between when the grabber closes and the intake unclamps, in seconds */
+    public static final double GRABBER_CLOSE_TIME_SECONDS = 0.2;
 
     /** The time in seconds for the grabber to open in OuttakeSequence */
     public static final double OUTTAKE_GRABBER_WAIT_TIME_SECONDS = PLACEHOLDER_DOUBLE;

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -18,21 +18,31 @@ public class IntakeSequence extends SequentialCommandGroup {
   private ParallelRaceGroup deployIntake =
       new RunCommand(intake::deploy, intake).withTimeout(Cal.Intake.AUTO_CLAMP_WAIT_TIME_SECONDS);
 
-  // run intake, move lift to intake position, and open the grabber, until the robot sees an object
-  // and the lift is in position
+  // run intake infinitely (until parallel command ends)
   private RunCommand runIntake = new RunCommand(intake::intakeGamePiece, intake);
+  
+  // trigger the lift to move to the intake position. This does not need a timeout because it is
+  // running in the parallel group, which is controlled by lift.readyToIntake()
   private InstantCommand liftToIntakePos =
       new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift);
+
+  // triggers the grabber to open when it is safe. Again, we do not care about time because it is in
+  // the parallel group.
   private InstantCommand openGrabber = new InstantCommand(lift::openGrabber, lift);
+
+  // run intake, move lift to intake position, and open the grabber, until the robot sees an object
+  // and the lift is in position
   private ParallelRaceGroup intakePrep =
       new ParallelCommandGroup(runIntake, liftToIntakePos, openGrabber).until(lift::readyToIntake);
 
+  // triggers the grabber to close
   private InstantCommand closeGrabber = new InstantCommand(lift::closeGrabber, lift);
-  
+
+  // immediately unclamps the intake.
   private InstantCommand unclampIntake = new InstantCommand(intake::unclampIntake, intake);
 
-  // this does not need a timeout even though it is a longer action, because it is the final action
-  // in the sequence
+  // triggers the lift to move to the starting position. This does not need a timeout even though it
+  // is a longer action, because it is the final action in the sequence
   private InstantCommand liftToStartPos =
       new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING), lift);
 

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -18,6 +18,8 @@ public class IntakeSequence extends SequentialCommandGroup {
   public IntakeSequence(Intake intake, Lift lift) {
     this.intake = intake;
     this.lift = lift;
+    addRequirements(intake, lift);
+
     // addCommands(deployIntake, intakePrep, stopIntake, closeGrabber, unclampIntake,
     // liftToStartPos);
     addCommands(
@@ -42,13 +44,15 @@ public class IntakeSequence extends SequentialCommandGroup {
                 // because it is in
                 // the parallel group.
                 new InstantCommand(lift::openGrabber, lift))
-            .andThen(new WaitUntilCommand(() -> (lift.atIntakePos() && intake.seeGamePiece()))),
+            .andThen(new WaitUntilCommand(() -> (lift.atPosition(Lift.LiftPosition.GRAB_FROM_INTAKE) && intake.seeGamePiece()))),
         // stop intake
         new InstantCommand(intake::stopIntakingGamePiece, intake),
 
         // triggers the grabber to close
-        new InstantCommand(lift::closeGrabber, lift)
-            .andThen(new WaitCommand(Cal.Lift.GRABBER_CLOSE_TIME_SECONDS)),
+        new InstantCommand(lift::closeGrabber, lift),
+        
+        // wait until the grabber has closed
+        new WaitCommand(Cal.Lift.GRABBER_CLOSE_TIME_SECONDS),
 
         // immediately unclamps the intake.
         new InstantCommand(intake::unclampIntake, intake)

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -1,8 +1,11 @@
 package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
 import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
+import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.Cal;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.Lift;
 import frc.robot.subsystems.Lift.LiftPosition;
@@ -11,15 +14,25 @@ public class IntakeSequence extends SequentialCommandGroup {
   private Intake intake;
   private Lift lift;
 
-  private InstantCommand deployIntake = new InstantCommand(intake::deploy, intake);
-  private InstantCommand runIntake = new InstantCommand(intake::intakeGamePiece, intake);
+  // deploy intake for specified amount of time
+  private ParallelRaceGroup deployIntake =
+      new RunCommand(intake::deploy, intake).withTimeout(Cal.Intake.AUTO_CLAMP_WAIT_TIME_SECONDS);
+
+  // run intake, move lift to intake position, and open the grabber, until the robot sees an object
+  // and the lift is in position
+  private RunCommand runIntake = new RunCommand(intake::intakeGamePiece, intake);
   private InstantCommand liftToIntakePos =
       new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift);
   private InstantCommand openGrabber = new InstantCommand(lift::openGrabber, lift);
   private ParallelRaceGroup intakePrep =
-      new ParallelRaceGroup(runIntake, liftToIntakePos, openGrabber).until(lift::readyToIntake);
+      new ParallelCommandGroup(runIntake, liftToIntakePos, openGrabber).until(lift::readyToIntake);
+
   private InstantCommand closeGrabber = new InstantCommand(lift::closeGrabber, lift);
+  
   private InstantCommand unclampIntake = new InstantCommand(intake::unclampIntake, intake);
+
+  // this does not need a timeout even though it is a longer action, because it is the final action
+  // in the sequence
   private InstantCommand liftToStartPos =
       new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING), lift);
 

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -1,46 +1,31 @@
 package frc.robot.commands;
 
-import edu.wpi.first.wpilibj2.command.CommandBase;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import frc.robot.subsystems.Intake;
 import frc.robot.subsystems.Lift;
+import frc.robot.subsystems.Lift.LiftPosition;
 
-public class IntakeSequence extends CommandBase {
+public class IntakeSequence extends SequentialCommandGroup {
   private Intake intake;
   private Lift lift;
+
+  private InstantCommand deployIntake = new InstantCommand(intake::deploy, intake);
+  private InstantCommand runIntake = new InstantCommand(intake::intakeGamePiece, intake);
+  private InstantCommand liftToIntakePos =
+      new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift);
+  private InstantCommand openGrabber = new InstantCommand(lift::openGrabber, lift);
+  private ParallelRaceGroup intakePrep =
+      new ParallelRaceGroup(runIntake, liftToIntakePos, openGrabber).until(lift::readyToIntake);
+  private InstantCommand closeGrabber = new InstantCommand(lift::closeGrabber, lift);
+  private InstantCommand unclampIntake = new InstantCommand(intake::unclampIntake, intake);
+  private InstantCommand liftToStartPos =
+      new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING), lift);
 
   public IntakeSequence(Intake intake, Lift lift) {
     this.intake = intake;
     this.lift = lift;
-  }
-
-  @Override
-  public void initialize() {
-    intake.deploy();
-    lift.setDesiredPosition(Lift.LiftPosition.GRAB_FROM_INTAKE);
-  }
-
-  @Override
-  public void execute() {
-    if (!lift.seeGamePiece()) {
-      intake.intakeGamePiece();
-    } else {
-      lift.closeGrabber();
-    }
-    // TODO fix this
-  }
-
-  @Override
-  public boolean isFinished() {
-    return lift.holdingGamePiece() ? true : false;
-  }
-
-  @Override
-  public void end(boolean interrupted) {
-    if (!interrupted) {
-      lift.setDesiredPosition(Lift.LiftPosition.STARTING);
-      if (lift.clearOfIntakeZone()) { // TODO put this directly into intake
-        intake.retract();
-      }
-    }
+    addCommands(deployIntake, intakePrep, closeGrabber, unclampIntake, liftToStartPos);
   }
 }

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -12,35 +12,27 @@ import frc.robot.subsystems.Lift;
 import frc.robot.subsystems.Lift.LiftPosition;
 
 public class IntakeSequence extends SequentialCommandGroup {
-  private Intake intake;
-  private Lift lift;
 
   public IntakeSequence(Intake intake, Lift lift) {
-    this.intake = intake;
-    this.lift = lift;
     addRequirements(intake, lift);
 
     addCommands(
         // deploy intake for specified amount of time
         new RunCommand(intake::deploy, intake).until(intake::atDesiredPosition),
 
-        // run intake, move lift to intake position, and open the grabber, until the robot sees an
-        // object
-        // and the lift is in position
+        // run intake and move lift to intake position, until the robot sees an
+        // object and the lift is in position
         new ParallelCommandGroup(
 
             // run intake
             new InstantCommand(intake::intakeGamePiece, intake),
 
-            // trigger the lift to move to the intake position. This does not need a timeout
-            // because it is
-            // running in the parallel group, which is controlled by readyToIntake()
-            new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift),
+            // trigger the lift to move to the intake position. This does not need a timeout because
+            // it is running in the parallel group, which is controlled by readyToIntake()
+            new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift)),
 
-            // triggers the grabber to open when it is safe. Again, we do not care about time
-            // because it is in
-            // the parallel group.
-            new InstantCommand(lift::openGrabber, lift)),
+        // triggers the grabber to open when it is safe
+        new InstantCommand(lift::openGrabber, lift),
 
         // wait until the lift is in position and the intake sees a game piece
         new WaitUntilCommand(
@@ -63,8 +55,7 @@ public class IntakeSequence extends SequentialCommandGroup {
         new WaitCommand(Cal.Intake.UNCLAMP_TIME_SECONDS),
 
         // triggers the lift to move to the starting position. This does not need a timeout even
-        // though it
-        // is a longer action, because it is the final action in the sequence
+        // though it is a longer action, because it is the final action in the sequence
         new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING), lift));
   }
 }

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -2,7 +2,6 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.ParallelCommandGroup;
-import edu.wpi.first.wpilibj2.command.ParallelRaceGroup;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 import edu.wpi.first.wpilibj2.command.WaitCommand;
@@ -16,53 +15,48 @@ public class IntakeSequence extends SequentialCommandGroup {
   private Intake intake;
   private Lift lift;
 
-  // deploy intake for specified amount of time
-  private ParallelRaceGroup deployIntake =
-      new RunCommand(intake::deploy, intake).until(intake::atDesiredPosition);
-
-  // run intake
-  private InstantCommand runIntake = new InstantCommand(intake::intakeGamePiece, intake);
-
-  // trigger the lift to move to the intake position. This does not need a timeout because it is
-  // running in the parallel group, which is controlled by lift.readyToIntake()
-  private InstantCommand liftToIntakePos =
-      new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift);
-
-  // triggers the grabber to open when it is safe. Again, we do not care about time because it is in
-  // the parallel group.
-  private InstantCommand openGrabber = new InstantCommand(lift::openGrabber, lift);
-
-  // completes when the lift is at the correct position and the intake sees a game piece
-  private WaitUntilCommand waitUntilReadyToIntake =
-      new WaitUntilCommand(() -> (lift.atIntakePos() && intake.seeGamePiece()));
-
-  // run intake, move lift to intake position, and open the grabber, until the robot sees an object
-  // and the lift is in position
-  private SequentialCommandGroup intakePrep =
-      new ParallelCommandGroup(runIntake, liftToIntakePos, openGrabber)
-          .andThen(waitUntilReadyToIntake);
-
-  // stop intake
-  private InstantCommand stopIntake = new InstantCommand(intake::stopIntakingGamePiece, intake);
-
-  // triggers the grabber to close
-  private SequentialCommandGroup closeGrabber =
-      new InstantCommand(lift::closeGrabber, lift)
-          .andThen(new WaitCommand(Cal.Lift.GRABBER_CLOSE_TIME_SECONDS));
-
-  // immediately unclamps the intake.
-  private SequentialCommandGroup unclampIntake =
-      new InstantCommand(intake::unclampIntake, intake)
-          .andThen(new WaitCommand(Cal.Intake.UNCLAMP_TIME_SECONDS));
-
-  // triggers the lift to move to the starting position. This does not need a timeout even though it
-  // is a longer action, because it is the final action in the sequence
-  private InstantCommand liftToStartPos =
-      new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING), lift);
-
   public IntakeSequence(Intake intake, Lift lift) {
     this.intake = intake;
     this.lift = lift;
-    addCommands(deployIntake, intakePrep, stopIntake, closeGrabber, unclampIntake, liftToStartPos);
+    // addCommands(deployIntake, intakePrep, stopIntake, closeGrabber, unclampIntake,
+    // liftToStartPos);
+    addCommands(
+        // deploy intake for specified amount of time
+        new RunCommand(intake::deploy, intake).until(intake::atDesiredPosition),
+
+        // run intake, move lift to intake position, and open the grabber, until the robot sees an
+        // object
+        // and the lift is in position
+        new ParallelCommandGroup(
+
+                // run intake
+                new InstantCommand(intake::intakeGamePiece, intake),
+
+                // trigger the lift to move to the intake position. This does not need a timeout
+                // because it is
+                // running in the parallel group, which is controlled by readyToIntake()
+                new InstantCommand(
+                    () -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift),
+
+                // triggers the grabber to open when it is safe. Again, we do not care about time
+                // because it is in
+                // the parallel group.
+                new InstantCommand(lift::openGrabber, lift))
+            .andThen(new WaitUntilCommand(() -> (lift.atIntakePos() && intake.seeGamePiece()))),
+        // stop intake
+        new InstantCommand(intake::stopIntakingGamePiece, intake),
+
+        // triggers the grabber to close
+        new InstantCommand(lift::closeGrabber, lift)
+            .andThen(new WaitCommand(Cal.Lift.GRABBER_CLOSE_TIME_SECONDS)),
+
+        // immediately unclamps the intake.
+        new InstantCommand(intake::unclampIntake, intake)
+            .andThen(new WaitCommand(Cal.Intake.UNCLAMP_TIME_SECONDS)),
+
+        // triggers the lift to move to the starting position. This does not need a timeout even
+        // though it
+        // is a longer action, because it is the final action in the sequence
+        new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING), lift));
   }
 }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -230,9 +230,18 @@ public class Intake extends SubsystemBase {
     }
 
     // If the intake has achieved its desired position, then cut power
+    if (atDesiredPosition()) {
+      deployMotorPID.setReference(0.0, CANSparkMax.ControlType.kVoltage);
+    }
+  }
+
+  /** If the intake has achieved its desired position, return true */
+  public boolean atDesiredPosition() {
     if (Math.abs(intakeDesiredPositionDegrees - deployMotorEncoder.getPosition())
         < Cal.Intake.POSITION_MARGIN_DEGREES) {
-      deployMotorPID.setReference(0.0, CANSparkMax.ControlType.kVoltage);
+      return true;
+    } else {
+      return false;
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -237,7 +237,7 @@ public class Intake extends SubsystemBase {
 
   /** If the intake has achieved its desired position, return true */
   public boolean atDesiredPosition() {
-    return (Math.abs(intakeDesiredPositionDegrees - deployMotorEncoder.getPosition()) < Cal.Intake.POSITION_MARGIN_DEGREES)
+    return (Math.abs(intakeDesiredPositionDegrees - deployMotorEncoder.getPosition()) < Cal.Intake.POSITION_MARGIN_DEGREES);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -192,7 +192,7 @@ public class Intake extends SubsystemBase {
     clamp.set(false);
   }
 
-  private void unclampIntake() {
+  public void unclampIntake() {
     clamp.set(true);
   }
 

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -237,12 +237,7 @@ public class Intake extends SubsystemBase {
 
   /** If the intake has achieved its desired position, return true */
   public boolean atDesiredPosition() {
-    if (Math.abs(intakeDesiredPositionDegrees - deployMotorEncoder.getPosition())
-        < Cal.Intake.POSITION_MARGIN_DEGREES) {
-      return true;
-    } else {
-      return false;
-    }
+    return (Math.abs(intakeDesiredPositionDegrees - deployMotorEncoder.getPosition()) < Cal.Intake.POSITION_MARGIN_DEGREES)
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -423,11 +423,6 @@ public class Lift extends SubsystemBase {
     }
   }
 
-  /** Returns true when the lift is at the intake position and the robot sees an object */
-  public boolean atIntakePos() {
-    return atPosition(LiftPosition.GRAB_FROM_INTAKE);
-  }
-
   @Override
   public void simulationPeriodic() {
     // This method will be called once per scheduler run during simulation

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -423,7 +423,8 @@ public class Lift extends SubsystemBase {
     }
   }
 
-  public boolean readyToIntake(){
+  /** Returns true when the lift is at the intake position and the robot sees an object */
+  public boolean readyToIntake() {
     return atPosition(LiftPosition.GRAB_FROM_INTAKE) && seeGamePiece();
   }
 

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -424,8 +424,8 @@ public class Lift extends SubsystemBase {
   }
 
   /** Returns true when the lift is at the intake position and the robot sees an object */
-  public boolean readyToIntake() {
-    return atPosition(LiftPosition.GRAB_FROM_INTAKE) && seeGamePiece();
+  public boolean atIntakePos() {
+    return atPosition(LiftPosition.GRAB_FROM_INTAKE);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -423,6 +423,10 @@ public class Lift extends SubsystemBase {
     }
   }
 
+  public boolean readyToIntake(){
+    return atPosition(LiftPosition.GRAB_FROM_INTAKE) && seeGamePiece();
+  }
+
   @Override
   public void simulationPeriodic() {
     // This method will be called once per scheduler run during simulation


### PR DESCRIPTION
Adds a sequential command sequence for intaking, based on what we discussed on Saturday.

(Ignore the removed code in `Intake.java` - it was the old intake sequence that we are not using. I recommend switching the GitHub view so you can look at the added code separately.)