### PR TITLE
Fixes to startScore and finishScore methods

### DIFF
--- a/src/main/java/frc/robot/commands/finishScore.java
+++ b/src/main/java/frc/robot/commands/finishScore.java
@@ -14,10 +14,12 @@ public class finishScore extends SequentialCommandGroup {
     addCommands(
         new InstantCommand(lift::openGrabber, lift),
         new WaitCommand(Cal.Lift.GRABBER_OPEN_TIME_SECONDS),
+        new InstantCommand(lift::closeGrabber, lift),
         new ConditionalCommand(
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.POST_SCORE_HIGH), lift)
                 .andThen(new WaitCommand(Cal.Lift.SAFE_TO_RETURN_TO_START_SECONDS)),
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING)),
             lift.scoreLoc::isScoringHigh));
+        new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING));
   }
 }

--- a/src/main/java/frc/robot/commands/finishScore.java
+++ b/src/main/java/frc/robot/commands/finishScore.java
@@ -16,10 +16,11 @@ public class finishScore extends SequentialCommandGroup {
         new WaitCommand(Cal.Lift.GRABBER_OPEN_TIME_SECONDS),
         new InstantCommand(lift::closeGrabber, lift),
         new ConditionalCommand(
+            // TODO consider whether we even need POST_SCORE_HIGH
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.POST_SCORE_HIGH), lift)
                 .andThen(new WaitCommand(Cal.Lift.SAFE_TO_RETURN_TO_START_SECONDS)),
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING)),
             lift.scoreLoc::isScoringHigh));
-        new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING));
+    new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.STARTING));
   }
 }

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -320,7 +320,7 @@ public class Lift extends SubsystemBase {
   }
 
   public void startScore() {
-    if (!scoreLoc.isCone()) {
+    if (scoreLoc.isCone()) {
       if (scoreLoc.getScoreHeight() == ScoreHeight.HIGH) {
         setDesiredPosition(LiftPosition.PRE_SCORE_HIGH_CONE);
       } else if (scoreLoc.getScoreHeight() == ScoreHeight.MID) {


### PR DESCRIPTION
*startScore: changed the if statement so that it would run if we are scoring a cone (basically, if scoreLoc.isCone() returns true)
*finishScore: added closeGrabber method call, and setDesiredPosition of the lift to STARTING at the very end