### PR TITLE
Renames most occurances of grabber to claw

### DIFF
--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -223,15 +223,15 @@ public final class Cal {
         ELEVATOR_START_MARGIN_INCHES = 1.0,
         ARM_START_MARGIN_DEGREES = 8.0;
 
-    /** Zone where the claw must be closed, in degrees. Bottom is closer to intake. */
-    public static final double CLAW_CLOSED_ZONE_BOTTOM_DEGREES = PLACEHOLDER_DOUBLE,
-        CLAW_CLOSED_ZONE_TOP_DEGREES = PLACEHOLDER_DOUBLE;
+    /** Zone where the claaaaaaw must be closed, in degrees. Bottom is closer to intake. */
+    public static final double CLAAAAAAW_CLOSED_ZONE_BOTTOM_DEGREES = PLACEHOLDER_DOUBLE,
+        CLAAAAAAW_CLOSED_ZONE_TOP_DEGREES = PLACEHOLDER_DOUBLE;
 
-    /** Time between when the claw opens or closes and the intake unclamps, in seconds */
-    public static final double CLAW_CLOSE_TIME_SECONDS = 0.2, CLAW_OPEN_TIME_SECONDS = 0.2;
+    /** Time between when the claaaaaaw opens or closes and the intake unclamps, in seconds */
+    public static final double CLAAAAAAW_CLOSE_TIME_SECONDS = 0.2, CLAAAAAAW_OPEN_TIME_SECONDS = 0.2;
 
-    /** The time in seconds for the claw to open in OuttakeSequence */
-    public static final double OUTTAKE_CLAW_WAIT_TIME_SECONDS = 0.2;
+    /** The time in seconds for the claaaaaaw to open in OuttakeSequence */
+    public static final double OUTTAKE_CLAAAAAAW_WAIT_TIME_SECONDS = 0.2;
 
     /**
      * The time in seconds it takes for it to be safe to return to the starting position, from the

--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -223,15 +223,15 @@ public final class Cal {
         ELEVATOR_START_MARGIN_INCHES = 1.0,
         ARM_START_MARGIN_DEGREES = 8.0;
 
-    /** Zone where the grabber must be closed, in degrees. Bottom is closer to intake. */
-    public static final double GRABBER_CLOSED_ZONE_BOTTOM_DEGREES = PLACEHOLDER_DOUBLE,
-        GRABBER_CLOSED_ZONE_TOP_DEGREES = PLACEHOLDER_DOUBLE;
+    /** Zone where the claw must be closed, in degrees. Bottom is closer to intake. */
+    public static final double CLAW_CLOSED_ZONE_BOTTOM_DEGREES = PLACEHOLDER_DOUBLE,
+        CLAW_CLOSED_ZONE_TOP_DEGREES = PLACEHOLDER_DOUBLE;
 
-    /** Time between when the grabber opens or closes and the intake unclamps, in seconds */
-    public static final double GRABBER_CLOSE_TIME_SECONDS = 0.2, GRABBER_OPEN_TIME_SECONDS = 0.2;
+    /** Time between when the claw opens or closes and the intake unclamps, in seconds */
+    public static final double CLAW_CLOSE_TIME_SECONDS = 0.2, CLAW_OPEN_TIME_SECONDS = 0.2;
 
-    /** The time in seconds for the grabber to open in OuttakeSequence */
-    public static final double OUTTAKE_GRABBER_WAIT_TIME_SECONDS = 0.2;
+    /** The time in seconds for the claw to open in OuttakeSequence */
+    public static final double OUTTAKE_CLAW_WAIT_TIME_SECONDS = 0.2;
 
     /**
      * The time in seconds it takes for it to be safe to return to the starting position, from the

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -189,8 +189,8 @@ public class RobotContainer {
     operatorController
         .rightBumper()
         .onTrue(new InstantCommand(() -> lights.toggleCode(Lights.LightCode.CONE), lights));
-    operatorController.leftTrigger().onTrue(new InstantCommand(lift::openGrabber, lift));
-    operatorController.leftTrigger().onFalse(new InstantCommand(lift::closeGrabber, lift));
+    operatorController.leftTrigger().onTrue(new InstantCommand(lift::openClaw, lift));
+    operatorController.leftTrigger().onFalse(new InstantCommand(lift::closeClaw, lift));
     operatorController.rightTrigger().onTrue(new InstantCommand(scoreLoc::toggleMiddleGrid));
     operatorController.rightTrigger().onFalse(new InstantCommand(scoreLoc::toggleMiddleGrid));
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -189,8 +189,8 @@ public class RobotContainer {
     operatorController
         .rightBumper()
         .onTrue(new InstantCommand(() -> lights.toggleCode(Lights.LightCode.CONE), lights));
-    operatorController.leftTrigger().onTrue(new InstantCommand(lift::openClaw, lift));
-    operatorController.leftTrigger().onFalse(new InstantCommand(lift::closeClaw, lift));
+    operatorController.leftTrigger().onTrue(new InstantCommand(lift::openTheClaaaaaaw, lift));
+    operatorController.leftTrigger().onFalse(new InstantCommand(lift::closeTheClaaaaaaw, lift));
     operatorController.rightTrigger().onTrue(new InstantCommand(scoreLoc::toggleMiddleGrid));
     operatorController.rightTrigger().onFalse(new InstantCommand(scoreLoc::toggleMiddleGrid));
 

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -31,8 +31,8 @@ public final class RobotMap {
   /** Intake clamp pneumatic channels */
   public static final int INTAKE_CLAMP_FORWARD_CHANNEL = 0;
 
-  /** Lift claw pneumatic channels */
-  public static final int LIFT_CLAW_CHANNEL = 1;
+  /** Lift claaaaaaw pneumatic channels */
+  public static final int LIFT_CLAAAAAAW_CHANNEL = 1;
 
   /** Sensor DIO */
   public static final int LIFT_GAME_PIECE_DIO = 0, INTAKE_GAME_PIECE_DIO = 1;

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -31,8 +31,8 @@ public final class RobotMap {
   /** Intake clamp pneumatic channels */
   public static final int INTAKE_CLAMP_FORWARD_CHANNEL = 0;
 
-  /** Lift grabbing pneumatic channels */
-  public static final int LIFT_GRABBING_CHANNEL = 1;
+  /** Lift claw pneumatic channels */
+  public static final int LIFT_CLAW_CHANNEL = 1;
 
   /** Sensor DIO */
   public static final int LIFT_GAME_PIECE_DIO = 0, INTAKE_GAME_PIECE_DIO = 1;

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -36,8 +36,8 @@ public class IntakeSequence extends SequentialCommandGroup {
             // it is running in the parallel group, which is controlled by readyToIntake()
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift)),
 
-        // triggers the grabber to open when it is safe
-        new InstantCommand(lift::openGrabber, lift),
+        // triggers the claw to open when it is safe
+        new InstantCommand(lift::openClaw, lift),
 
         // wait until the lift is in position and the intake sees a game piece
         new WaitUntilCommand(
@@ -46,11 +46,11 @@ public class IntakeSequence extends SequentialCommandGroup {
         // stop intake
         new InstantCommand(intake::stopIntakingGamePiece, intake),
 
-        // triggers the grabber to close
-        new InstantCommand(lift::closeGrabber, lift),
+        // triggers the claw to close
+        new InstantCommand(lift::closeClaw, lift),
 
-        // wait until the grabber has closed
-        new WaitCommand(Cal.Lift.GRABBER_CLOSE_TIME_SECONDS),
+        // wait until the claw has closed
+        new WaitCommand(Cal.Lift.CLAW_CLOSE_TIME_SECONDS),
 
         // immediately unclamps the intake.
         new InstantCommand(

--- a/src/main/java/frc/robot/commands/IntakeSequence.java
+++ b/src/main/java/frc/robot/commands/IntakeSequence.java
@@ -36,8 +36,8 @@ public class IntakeSequence extends SequentialCommandGroup {
             // it is running in the parallel group, which is controlled by readyToIntake()
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.GRAB_FROM_INTAKE), lift)),
 
-        // triggers the claw to open when it is safe
-        new InstantCommand(lift::openClaw, lift),
+        // triggers the claaaaaaw to open when it is safe
+        new InstantCommand(lift::openTheClaaaaaaw, lift),
 
         // wait until the lift is in position and the intake sees a game piece
         new WaitUntilCommand(
@@ -46,11 +46,11 @@ public class IntakeSequence extends SequentialCommandGroup {
         // stop intake
         new InstantCommand(intake::stopIntakingGamePiece, intake),
 
-        // triggers the claw to close
-        new InstantCommand(lift::closeClaw, lift),
+        // triggers the claaaaaaw to close
+        new InstantCommand(lift::closeTheClaaaaaaw, lift),
 
-        // wait until the claw has closed
-        new WaitCommand(Cal.Lift.CLAW_CLOSE_TIME_SECONDS),
+        // wait until the claaaaaaw has closed
+        new WaitCommand(Cal.Lift.CLAAAAAAW_CLOSE_TIME_SECONDS),
 
         // immediately unclamps the intake.
         new InstantCommand(

--- a/src/main/java/frc/robot/commands/OuttakeSequence.java
+++ b/src/main/java/frc/robot/commands/OuttakeSequence.java
@@ -8,7 +8,7 @@ import frc.robot.Cal;
 import frc.robot.subsystems.Lift;
 import frc.robot.subsystems.Lift.LiftPosition;
 
-/** moves lift to OUTTAKING position, opens the claw, waits, closes the claw */
+/** moves lift to OUTTAKING position, opens the claaaaaaw, waits, closes the claaaaaaw */
 public class OuttakeSequence extends SequentialCommandGroup {
 
   public OuttakeSequence(Lift lift) {
@@ -16,8 +16,8 @@ public class OuttakeSequence extends SequentialCommandGroup {
     addCommands(
         new RunCommand(() -> lift.setDesiredPosition(LiftPosition.OUTTAKING), lift)
             .until(() -> lift.atPosition(LiftPosition.OUTTAKING)),
-        new InstantCommand(lift::openClaw, lift),
-        new WaitCommand(Cal.Lift.OUTTAKE_CLAW_WAIT_TIME_SECONDS),
-        new InstantCommand(lift::closeClaw, lift));
+        new InstantCommand(lift::openTheClaaaaaaw, lift),
+        new WaitCommand(Cal.Lift.OUTTAKE_CLAAAAAAW_WAIT_TIME_SECONDS),
+        new InstantCommand(lift::closeTheClaaaaaaw, lift));
   }
 }

--- a/src/main/java/frc/robot/commands/OuttakeSequence.java
+++ b/src/main/java/frc/robot/commands/OuttakeSequence.java
@@ -8,7 +8,7 @@ import frc.robot.Cal;
 import frc.robot.subsystems.Lift;
 import frc.robot.subsystems.Lift.LiftPosition;
 
-/** moves lift to OUTTAKING position, opens the grabber, waits, closes the grabber */
+/** moves lift to OUTTAKING position, opens the claw, waits, closes the claw */
 public class OuttakeSequence extends SequentialCommandGroup {
 
   public OuttakeSequence(Lift lift) {
@@ -16,8 +16,8 @@ public class OuttakeSequence extends SequentialCommandGroup {
     addCommands(
         new RunCommand(() -> lift.setDesiredPosition(LiftPosition.OUTTAKING), lift)
             .until(() -> lift.atPosition(LiftPosition.OUTTAKING)),
-        new InstantCommand(lift::openGrabber, lift),
-        new WaitCommand(Cal.Lift.OUTTAKE_GRABBER_WAIT_TIME_SECONDS),
-        new InstantCommand(lift::closeGrabber, lift));
+        new InstantCommand(lift::openClaw, lift),
+        new WaitCommand(Cal.Lift.OUTTAKE_CLAW_WAIT_TIME_SECONDS),
+        new InstantCommand(lift::closeClaw, lift));
   }
 }

--- a/src/main/java/frc/robot/commands/finishScore.java
+++ b/src/main/java/frc/robot/commands/finishScore.java
@@ -12,9 +12,9 @@ public class finishScore extends SequentialCommandGroup {
   public finishScore(Lift lift) {
     addRequirements(lift);
     addCommands(
-        new InstantCommand(lift::openClaw, lift),
-        new WaitCommand(Cal.Lift.CLAW_OPEN_TIME_SECONDS),
-        new InstantCommand(lift::closeClaw, lift),
+        new InstantCommand(lift::openTheClaaaaaaw, lift),
+        new WaitCommand(Cal.Lift.CLAAAAAAW_OPEN_TIME_SECONDS),
+        new InstantCommand(lift::closeTheClaaaaaaw, lift),
         new ConditionalCommand(
             // TODO consider whether we even need POST_SCORE_HIGH
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.POST_SCORE_HIGH), lift)

--- a/src/main/java/frc/robot/commands/finishScore.java
+++ b/src/main/java/frc/robot/commands/finishScore.java
@@ -12,9 +12,9 @@ public class finishScore extends SequentialCommandGroup {
   public finishScore(Lift lift) {
     addRequirements(lift);
     addCommands(
-        new InstantCommand(lift::openGrabber, lift),
-        new WaitCommand(Cal.Lift.GRABBER_OPEN_TIME_SECONDS),
-        new InstantCommand(lift::closeGrabber, lift),
+        new InstantCommand(lift::openClaw, lift),
+        new WaitCommand(Cal.Lift.CLAW_OPEN_TIME_SECONDS),
+        new InstantCommand(lift::closeClaw, lift),
         new ConditionalCommand(
             // TODO consider whether we even need POST_SCORE_HIGH
             new InstantCommand(() -> lift.setDesiredPosition(LiftPosition.POST_SCORE_HIGH), lift)

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -30,7 +30,7 @@ import frc.robot.utils.SendableHelper;
 import frc.robot.utils.SparkMaxUtils;
 import java.util.TreeMap;
 
-/** Contains code for elevator, arm, and game piece grabber */
+/** Contains code for elevator, arm, and game piece claw */
 public class Lift extends SubsystemBase {
 
   /** Overall position of the lift including both elevator and arm */
@@ -82,8 +82,8 @@ public class Lift extends SubsystemBase {
               Cal.Lift.ARM_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED));
 
   private CANSparkMax armMotor = new CANSparkMax(RobotMap.ARM_MOTOR_CAN_ID, MotorType.kBrushless);
-  private Solenoid grabber =
-      new Solenoid(PneumaticsModuleType.REVPH, RobotMap.LIFT_GRABBING_CHANNEL);
+  private Solenoid claw =
+      new Solenoid(PneumaticsModuleType.REVPH, RobotMap.LIFT_CLAW_CHANNEL);
 
   // Sensors
   private final RelativeEncoder elevatorLeftEncoder = elevatorLeft.getEncoder();
@@ -98,7 +98,7 @@ public class Lift extends SubsystemBase {
   // Members
   private LiftPosition latestPosition = LiftPosition.STARTING;
   private LiftPosition desiredPosition = LiftPosition.STARTING;
-  private boolean desiredGrabberClosed = true;
+  private boolean desiredClawClosed = true;
   public ScoringLocationUtil scoreLoc;
 
   /**
@@ -258,12 +258,12 @@ public class Lift extends SubsystemBase {
     armMotor.setVoltage(demand);
   }
 
-  public void closeGrabber() {
-    desiredGrabberClosed = true;
+  public void closeClaw() {
+    desiredClawClosed = true;
   }
 
-  public void openGrabber() {
-    desiredGrabberClosed = false;
+  public void openClaw() {
+    desiredClawClosed = false;
   }
 
   /** Returns true if the game piece sensor sees a game piece */
@@ -409,14 +409,14 @@ public class Lift extends SubsystemBase {
       controlPosition(desiredPosition);
     }
 
-    // If the grabber is set to open and it is safe to open, open the grabber (drop). Otherwise,
+    // If the claw is set to open and it is safe to open, open the claw (drop). Otherwise,
     // close it (grab).
-    if (!desiredGrabberClosed
-        && (armEncoder.getPosition() > Cal.Lift.GRABBER_CLOSED_ZONE_TOP_DEGREES
-            || armEncoder.getPosition() < Cal.Lift.GRABBER_CLOSED_ZONE_BOTTOM_DEGREES)) {
-      grabber.set(false); // drop
+    if (!desiredClawClosed
+        && (armEncoder.getPosition() > Cal.Lift.CLAW_CLOSED_ZONE_TOP_DEGREES
+            || armEncoder.getPosition() < Cal.Lift.CLAW_CLOSED_ZONE_BOTTOM_DEGREES)) {
+      claw.set(false); // drop
     } else {
-      grabber.set(true); // grab
+      claw.set(true); // grab
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/Lift.java
+++ b/src/main/java/frc/robot/subsystems/Lift.java
@@ -30,7 +30,7 @@ import frc.robot.utils.SendableHelper;
 import frc.robot.utils.SparkMaxUtils;
 import java.util.TreeMap;
 
-/** Contains code for elevator, arm, and game piece claw */
+/** Contains code for elevator, arm, and game piece claaaaaaw */
 public class Lift extends SubsystemBase {
 
   /** Overall position of the lift including both elevator and arm */
@@ -82,8 +82,8 @@ public class Lift extends SubsystemBase {
               Cal.Lift.ARM_MAX_ACCELERATION_DEG_PER_SECOND_SQUARED));
 
   private CANSparkMax armMotor = new CANSparkMax(RobotMap.ARM_MOTOR_CAN_ID, MotorType.kBrushless);
-  private Solenoid claw =
-      new Solenoid(PneumaticsModuleType.REVPH, RobotMap.LIFT_CLAW_CHANNEL);
+  private Solenoid theClaaaaaaw =
+      new Solenoid(PneumaticsModuleType.REVPH, RobotMap.LIFT_CLAAAAAAW_CHANNEL);
 
   // Sensors
   private final RelativeEncoder elevatorLeftEncoder = elevatorLeft.getEncoder();
@@ -98,7 +98,7 @@ public class Lift extends SubsystemBase {
   // Members
   private LiftPosition latestPosition = LiftPosition.STARTING;
   private LiftPosition desiredPosition = LiftPosition.STARTING;
-  private boolean desiredClawClosed = true;
+  private boolean desiredClaaaaaawClosed = true;
   public ScoringLocationUtil scoreLoc;
 
   /**
@@ -258,12 +258,12 @@ public class Lift extends SubsystemBase {
     armMotor.setVoltage(demand);
   }
 
-  public void closeClaw() {
-    desiredClawClosed = true;
+  public void closeTheClaaaaaaw() {
+    desiredClaaaaaawClosed = true;
   }
 
-  public void openClaw() {
-    desiredClawClosed = false;
+  public void openTheClaaaaaaw() {
+    desiredClaaaaaawClosed = false;
   }
 
   /** Returns true if the game piece sensor sees a game piece */
@@ -409,14 +409,14 @@ public class Lift extends SubsystemBase {
       controlPosition(desiredPosition);
     }
 
-    // If the claw is set to open and it is safe to open, open the claw (drop). Otherwise,
+    // If the claaaaaaw is set to open and it is safe to open, open the claaaaaaw (drop). Otherwise,
     // close it (grab).
-    if (!desiredClawClosed
-        && (armEncoder.getPosition() > Cal.Lift.CLAW_CLOSED_ZONE_TOP_DEGREES
-            || armEncoder.getPosition() < Cal.Lift.CLAW_CLOSED_ZONE_BOTTOM_DEGREES)) {
-      claw.set(false); // drop
+    if (!desiredClaaaaaawClosed
+        && (armEncoder.getPosition() > Cal.Lift.CLAAAAAAW_CLOSED_ZONE_TOP_DEGREES
+            || armEncoder.getPosition() < Cal.Lift.CLAAAAAAW_CLOSED_ZONE_BOTTOM_DEGREES)) {
+      theClaaaaaaw.set(false); // drop
     } else {
-      claw.set(true); // grab
+      theClaaaaaaw.set(true); // grab
     }
   }
 


### PR DESCRIPTION
This PR changes most instances of grabber to claw. There has been lengthy discussion about the term grabber vs gripper. However, I propose that we switch to claw. This is based on the fact that there is a precedent for using the term claw, notably from both Nick (see figure 1) and Jay (see figure 2).

![image](https://user-images.githubusercontent.com/22648713/219464605-bf292a15-5572-4766-beb8-77c621e1a693.png)
Figure 1

![image](https://user-images.githubusercontent.com/22648713/219464672-c062390d-08f8-492e-ac21-645caeef5a88.png)
Figure 2

Claw also uses less characters and syllables, thus being more efficient to type and say (and uses less storage on the NI roboRIO 2.0). Additionally, claw is a way to resolve the argument about gripper vs grabber without having to pick sides.

Lastly, Jay made it clear that he did not believe that I would create this PR (see figure 3). I simply cannot let that heinous lack of faith in my work ethic go unaddressed.

![image](https://user-images.githubusercontent.com/22648713/219465308-81a15770-6558-42a0-835e-499c6c9b27cc.png)
Figure 3

Your move, Jay.