### PR TITLE
Adds SimpleDriveToTag Command

### DIFF
--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -269,6 +269,7 @@ public final class Cal {
 
   public static final int SPARK_INIT_RETRY_ATTEMPTS = 5;
 
-  public static final double DISTANCE_BACK_FROM_TAG_METERS = 1;
+  public static final double DISTANCE_BACK_FROM_TAG_LOW_METERS = 1;
+  public static final double DISTANCE_BACK_FROM_TAG_MID_HIGH_METERS = 0.5;
   public static final double HORIZONTAL_DISTANCE_TAG_TO_RIGHT_CONE_METERS = PLACEHOLDER_DOUBLE;
 }

--- a/src/main/java/frc/robot/Cal.java
+++ b/src/main/java/frc/robot/Cal.java
@@ -268,4 +268,7 @@ public final class Cal {
   }
 
   public static final int SPARK_INIT_RETRY_ATTEMPTS = 5;
+
+  public static final double DISTANCE_BACK_FROM_TAG_METERS = 1;
+  public static final double HORIZONTAL_DISTANCE_TAG_TO_RIGHT_CONE_METERS = PLACEHOLDER_DOUBLE;
 }

--- a/src/main/java/frc/robot/RobotMap.java
+++ b/src/main/java/frc/robot/RobotMap.java
@@ -31,7 +31,7 @@ public final class RobotMap {
   /** Intake clamp pneumatic channels */
   public static final int INTAKE_CLAMP_FORWARD_CHANNEL = 0;
 
-  /** Lift grabbing pneumatic channels */
+  /** Lift grabbingf pneumatic channels */
   public static final int LIFT_GRABBING_CHANNEL = 1;
 
   /** Sensor DIO */

--- a/src/main/java/frc/robot/commands/SimpleDriveToTag.java
+++ b/src/main/java/frc/robot/commands/SimpleDriveToTag.java
@@ -4,7 +4,6 @@ import com.pathplanner.lib.PathConstraints;
 import com.pathplanner.lib.PathPlanner;
 import com.pathplanner.lib.PathPlannerTrajectory;
 import com.pathplanner.lib.PathPoint;
-
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
@@ -14,42 +13,46 @@ import frc.robot.subsystems.TagLimelight;
 import frc.robot.subsystems.drive.DriveSubsystem;
 
 public class SimpleDriveToTag extends CommandBase {
-    private TagLimelight limelight;
-    private DriveSubsystem drive;
+  private TagLimelight limelight;
+  private DriveSubsystem drive;
 
-    public SimpleDriveToTag(TagLimelight limelight, DriveSubsystem drive){
-        addRequirements(limelight, drive);
-        this.limelight = limelight;
-        this.drive = drive;
+  public SimpleDriveToTag(TagLimelight limelight, DriveSubsystem drive) {
+    addRequirements(limelight, drive);
+    this.limelight = limelight;
+    this.drive = drive;
+  }
+
+  @Override
+  public void execute() {
+    // Rotation2d robotRotation = drive.getPose().getRotation();
+    // Translation2d robotPos = drive.getPose().getTranslation();
+    if (limelight.isValidTarget()) {
+      Translation2d zeroTranslation = new Translation2d(0, 0);
+      Rotation2d zeroRotation = new Rotation2d(0);
+      Pose2d currentPose = drive.getPose();
+
+      Translation2d tagPosFromRobot = limelight.getTargetTranslation();
+      Rotation2d tagAngleRelativeToRobot =
+          new Rotation2d(tagPosFromRobot.getY() / tagPosFromRobot.getX());
+      Pose2d tagPoseFromRobot = new Pose2d(tagPosFromRobot, tagAngleRelativeToRobot);
+
+      // double correctedXVal = -(tagPos.getX());
+      // double correctedYVal = -(tagPos.getY());
+      // Translation2d correctedTagRelativeToRobot = new Translation2d(correctedXVal,
+      // correctedYVal);
+      // PathPoint robotPoint = new PathPoint(zeroTranslation, zeroRotation);
+      // PathPoint tagPoint = new PathPoint(correctedTagRelativeToRobot, tagAngleRelativeToRobot);
+
+      // TODO get actual limelight position
+      // TODO get translation of intended robot loc vs tag loc
+      PathPlannerTrajectory robotToTag =
+          PathPlanner.generatePath(
+              new PathConstraints(
+                  Cal.SwerveSubsystem.MAX_LINEAR_SPEED_METERS_PER_SEC,
+                  Cal.SwerveSubsystem.MAX_LINEAR_ACCELERATION_METERS_PER_SEC_SQ),
+              new PathPoint(currentPose.getTranslation(), currentPose.getRotation()),
+              new PathPoint(tagPoseFromRobot.getTranslation(), tagAngleRelativeToRobot));
+      drive.followTrajectoryCommand(robotToTag, false);
     }
-
-    @Override
-    public void execute(){
-        // Rotation2d robotRotation = drive.getPose().getRotation();
-        // Translation2d robotPos = drive.getPose().getTranslation();
-        if (limelight.isValidTarget()){
-            Translation2d zeroTranslation = new Translation2d(0, 0);
-            Rotation2d zeroRotation = new Rotation2d(0);
-            Pose2d currentPose = drive.getPose();
-        
-            Translation2d tagPosFromRobot = limelight.getTargetTranslation();
-            Rotation2d tagAngleRelativeToRobot = new Rotation2d(tagPosFromRobot.getY() / tagPosFromRobot.getX());
-            Pose2d tagPoseFromRobot = new Pose2d(tagPosFromRobot, tagAngleRelativeToRobot);
-
-            // double correctedXVal = -(tagPos.getX());
-            // double correctedYVal = -(tagPos.getY());
-            // Translation2d correctedTagRelativeToRobot = new Translation2d(correctedXVal, correctedYVal);
-            // PathPoint robotPoint = new PathPoint(zeroTranslation, zeroRotation);
-            // PathPoint tagPoint = new PathPoint(correctedTagRelativeToRobot, tagAngleRelativeToRobot);
-            
-            // TODO get actual limelight position
-            // TODO get translation of intended robot loc vs tag loc
-            PathPlannerTrajectory robotToTag = PathPlanner.generatePath(
-                new PathConstraints(Cal.SwerveSubsystem.MAX_LINEAR_SPEED_METERS_PER_SEC, Cal.SwerveSubsystem.MAX_LINEAR_ACCELERATION_METERS_PER_SEC_SQ),
-                new PathPoint(currentPose.getTranslation(), currentPose.getRotation()),
-                new PathPoint(tagPoseFromRobot.getTranslation(), tagAngleRelativeToRobot)
-            );
-            drive.followTrajectoryCommand(robotToTag, false);
-        }
-    }
+  }
 }

--- a/src/main/java/frc/robot/commands/SimpleDriveToTag.java
+++ b/src/main/java/frc/robot/commands/SimpleDriveToTag.java
@@ -1,0 +1,42 @@
+package frc.robot.commands;
+
+import com.pathplanner.lib.PathConstraints;
+import com.pathplanner.lib.PathPlanner;
+import com.pathplanner.lib.PathPlannerTrajectory;
+import com.pathplanner.lib.PathPoint;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.subsystems.TagLimelight;
+import frc.robot.subsystems.drive.DriveSubsystem;
+
+public class SimpleDriveToTag extends CommandBase {
+    private TagLimelight limelight;
+    private DriveSubsystem drive;
+
+    public SimpleDriveToTag(TagLimelight limelight, DriveSubsystem drive){
+        addRequirements(limelight, drive);
+        this.limelight = limelight;
+        this.drive = drive;
+    }
+
+    @Override
+    public void execute(){
+        // Rotation2d robotRotation = drive.getPose().getRotation();
+        // Translation2d robotPos = drive.getPose().getTranslation();
+        if (limelight.isValidTarget()){
+            Translation2d tagRelativeToRobot = limelight.getTargetTranslation();
+            double correctedXVal = -(tagRelativeToRobot.getX());
+            double correctedYVal = -(tagRelativeToRobot.getY());
+            Translation2d correctedTagRelativeToRobot = new Translation2d(correctedXVal, correctedYVal);
+            Translation2d zeroedTranslation = new Translation2d(0, 0);
+            Rotation2d zeroedRotation = new Rotation2d(0);
+            PathPoint robotPoint = new PathPoint(zeroedTranslation, zeroedRotation);
+            PathPoint tagPoint = new PathPoint(correctedTagRelativeToRobot, f)
+            // PathPlannerTrajectory robotToTag = PathPlanner.generatePath(
+                
+            );
+        }
+    }
+}

--- a/src/main/java/frc/robot/commands/SimpleDriveToTag.java
+++ b/src/main/java/frc/robot/commands/SimpleDriveToTag.java
@@ -50,9 +50,16 @@ public class SimpleDriveToTag extends CommandBase {
         horizTranslationFromTag = 0;
       }
 
+      double backTranslationFromTag;
+      if (scoreLoc.getScoreHeight() == ScoringLocationUtil.ScoreHeight.LOW){
+        backTranslationFromTag = Cal.DISTANCE_BACK_FROM_TAG_LOW_METERS;
+      } else {
+        backTranslationFromTag = Cal.DISTANCE_BACK_FROM_TAG_MID_HIGH_METERS;
+      }
+
       Translation2d locationToDriveTo =
           new Translation2d(
-              tagPosFromNormalizedRobot.getX() + Cal.DISTANCE_BACK_FROM_TAG_METERS,
+              tagPosFromNormalizedRobot.getX() + backTranslationFromTag,
               tagPosFromNormalizedRobot.getY() + horizTranslationFromTag);
 
       double angleToRotate = -robotPose.getRotation().getDegrees();

--- a/src/main/java/frc/robot/commands/SimpleDriveToTag.java
+++ b/src/main/java/frc/robot/commands/SimpleDriveToTag.java
@@ -5,9 +5,11 @@ import com.pathplanner.lib.PathPlanner;
 import com.pathplanner.lib.PathPlannerTrajectory;
 import com.pathplanner.lib.PathPoint;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.robot.Cal;
 import frc.robot.subsystems.TagLimelight;
 import frc.robot.subsystems.drive.DriveSubsystem;
 
@@ -26,17 +28,28 @@ public class SimpleDriveToTag extends CommandBase {
         // Rotation2d robotRotation = drive.getPose().getRotation();
         // Translation2d robotPos = drive.getPose().getTranslation();
         if (limelight.isValidTarget()){
-            Translation2d tagRelativeToRobot = limelight.getTargetTranslation();
-            double correctedXVal = -(tagRelativeToRobot.getX());
-            double correctedYVal = -(tagRelativeToRobot.getY());
-            Translation2d correctedTagRelativeToRobot = new Translation2d(correctedXVal, correctedYVal);
-            Translation2d zeroedTranslation = new Translation2d(0, 0);
-            Rotation2d zeroedRotation = new Rotation2d(0);
-            PathPoint robotPoint = new PathPoint(zeroedTranslation, zeroedRotation);
-            PathPoint tagPoint = new PathPoint(correctedTagRelativeToRobot, f)
-            // PathPlannerTrajectory robotToTag = PathPlanner.generatePath(
-                
+            Translation2d zeroTranslation = new Translation2d(0, 0);
+            Rotation2d zeroRotation = new Rotation2d(0);
+            Pose2d currentPose = drive.getPose();
+        
+            Translation2d tagPosFromRobot = limelight.getTargetTranslation();
+            Rotation2d tagAngleRelativeToRobot = new Rotation2d(tagPosFromRobot.getY() / tagPosFromRobot.getX());
+            Pose2d tagPoseFromRobot = new Pose2d(tagPosFromRobot, tagAngleRelativeToRobot);
+
+            // double correctedXVal = -(tagPos.getX());
+            // double correctedYVal = -(tagPos.getY());
+            // Translation2d correctedTagRelativeToRobot = new Translation2d(correctedXVal, correctedYVal);
+            // PathPoint robotPoint = new PathPoint(zeroTranslation, zeroRotation);
+            // PathPoint tagPoint = new PathPoint(correctedTagRelativeToRobot, tagAngleRelativeToRobot);
+            
+            // TODO get actual limelight position
+            // TODO get translation of intended robot loc vs tag loc
+            PathPlannerTrajectory robotToTag = PathPlanner.generatePath(
+                new PathConstraints(Cal.SwerveSubsystem.MAX_LINEAR_SPEED_METERS_PER_SEC, Cal.SwerveSubsystem.MAX_LINEAR_ACCELERATION_METERS_PER_SEC_SQ),
+                new PathPoint(currentPose.getTranslation(), currentPose.getRotation()),
+                new PathPoint(tagPoseFromRobot.getTranslation(), tagAngleRelativeToRobot)
             );
+            drive.followTrajectoryCommand(robotToTag, false);
         }
     }
 }


### PR DESCRIPTION
This command drives the limelight to a tag that it sees. At the moment, it does not check if the tag is ours; that can be added. It finds the tag's location on the field based on the location relative to the robot and the robot's odometry. The tag’s coordinates relative to the field are obtained by applying a rotation matrix to the tag’s coordinates relative to the robot (from the Limelight), and then applying to that result a translation vector equal to the robot’s position relative to the field (from the swerve odometry). This may not have been necessary since the Limelight will do a good job identifying the tag correctly and we could have just gotten the coordinates from there, but oh well I already figured this out. We can change it to that if that's better.