### PR TITLE
Adjust chassis speeds for second order dynamics

### DIFF
--- a/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/drive/DriveSubsystem.java
@@ -11,6 +11,7 @@ import com.pathplanner.lib.commands.PPSwerveControllerCommand;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Twist2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
@@ -24,6 +25,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Cal;
 import frc.robot.Constants;
 import frc.robot.RobotMap;
+import frc.robot.utils.GeometryUtils;
 
 public class DriveSubsystem extends SubsystemBase {
   private double targetHeadingDegrees;
@@ -124,6 +126,28 @@ public class DriveSubsystem extends SubsystemBase {
   }
 
   /**
+   * Correction for swerve second order dynamics issue. Borrowed from 254:
+   * https://github.com/Team254/FRC-2022-Public/blob/main/src/main/java/com/team254/frc2022/subsystems/Drive.java#L325
+   * Discussion:
+   * https://www.chiefdelphi.com/t/whitepaper-swerve-drive-skew-and-second-order-kinematics/416964
+   */
+  private static ChassisSpeeds correctForDynamics(ChassisSpeeds originalSpeeds) {
+    final double LOOP_TIME_S = 0.02;
+    Pose2d futureRobotPose =
+        new Pose2d(
+            originalSpeeds.vxMetersPerSecond * LOOP_TIME_S,
+            originalSpeeds.vyMetersPerSecond * LOOP_TIME_S,
+            Rotation2d.fromRadians(originalSpeeds.omegaRadiansPerSecond * LOOP_TIME_S));
+    Twist2d twistForPose = GeometryUtils.log(futureRobotPose);
+    ChassisSpeeds updatedSpeeds =
+        new ChassisSpeeds(
+            twistForPose.dx / LOOP_TIME_S,
+            twistForPose.dy / LOOP_TIME_S,
+            twistForPose.dtheta / LOOP_TIME_S);
+    return updatedSpeeds;
+  }
+
+  /**
    * Method to drive the robot using joystick info.
    *
    * @param xSpeed Desired speed of the robot in the x direction (forward), [-1,1].
@@ -142,12 +166,17 @@ public class DriveSubsystem extends SubsystemBase {
       ySpeed /= 2;
     }
 
+    ChassisSpeeds desiredChassisSpeeds =
+        fieldRelative
+            ? ChassisSpeeds.fromFieldRelativeSpeeds(
+                xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw()))
+            : new ChassisSpeeds(xSpeed, ySpeed, rot);
+
+    desiredChassisSpeeds = correctForDynamics(desiredChassisSpeeds);
+
     var swerveModuleStates =
-        Constants.SwerveDrive.DRIVE_KINEMATICS.toSwerveModuleStates(
-            fieldRelative
-                ? ChassisSpeeds.fromFieldRelativeSpeeds(
-                    xSpeed, ySpeed, rot, Rotation2d.fromDegrees(gyro.getYaw()))
-                : new ChassisSpeeds(xSpeed, ySpeed, rot));
+        Constants.SwerveDrive.DRIVE_KINEMATICS.toSwerveModuleStates(desiredChassisSpeeds);
+
     SwerveDriveKinematics.desaturateWheelSpeeds(
         swerveModuleStates, Constants.SwerveDrive.MAX_SPEED_METERS_PER_SECOND);
     frontLeft.setDesiredState(swerveModuleStates[0]);

--- a/src/main/java/frc/robot/utils/GeometryUtils.java
+++ b/src/main/java/frc/robot/utils/GeometryUtils.java
@@ -1,0 +1,53 @@
+package frc.robot.utils;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Twist2d;
+
+public class GeometryUtils {
+  private static final double kEps = 1E-9;
+
+  /**
+   * Obtain a new Pose2d from a (constant curvature) velocity. See:
+   * https://github.com/strasdat/Sophus/blob/master/sophus/se2.hpp . Borrowed from 254:
+   * https://github.com/Team254/FRC-2022-Public/blob/b5da3c760b78d598b492e1cc51d8331c2ad50f6a/src/main/java/com/team254/lib/geometry/Pose2d.java
+   */
+  public static Pose2d exp(final Twist2d delta) {
+    double sin_theta = Math.sin(delta.dtheta);
+    double cos_theta = Math.cos(delta.dtheta);
+    double s, c;
+    if (Math.abs(delta.dtheta) < kEps) {
+      s = 1.0 - 1.0 / 6.0 * delta.dtheta * delta.dtheta;
+      c = .5 * delta.dtheta;
+    } else {
+      s = sin_theta / delta.dtheta;
+      c = (1.0 - cos_theta) / delta.dtheta;
+    }
+    return new Pose2d(
+        new Translation2d(delta.dx * s - delta.dy * c, delta.dx * c + delta.dy * s),
+        new Rotation2d(cos_theta, sin_theta));
+  }
+
+  /**
+   * Logical inverse of the above. Borrowed from 254:
+   * https://github.com/Team254/FRC-2022-Public/blob/b5da3c760b78d598b492e1cc51d8331c2ad50f6a/src/main/java/com/team254/lib/geometry/Pose2d.java
+   */
+  public static Twist2d log(final Pose2d transform) {
+    final double dtheta = transform.getRotation().getRadians();
+    final double half_dtheta = 0.5 * dtheta;
+    final double cos_minus_one = Math.cos(transform.getRotation().getRadians()) - 1.0;
+    double halftheta_by_tan_of_halfdtheta;
+    if (Math.abs(cos_minus_one) < kEps) {
+      halftheta_by_tan_of_halfdtheta = 1.0 - 1.0 / 12.0 * dtheta * dtheta;
+    } else {
+      halftheta_by_tan_of_halfdtheta =
+          -(half_dtheta * Math.sin(transform.getRotation().getRadians())) / cos_minus_one;
+    }
+    final Translation2d translation_part =
+        transform
+            .getTranslation()
+            .rotateBy(new Rotation2d(halftheta_by_tan_of_halfdtheta, -half_dtheta));
+    return new Twist2d(translation_part.getX(), translation_part.getY(), dtheta);
+  }
+}


### PR DESCRIPTION
Correction for swerve second order dynamics issue. Without this correction, if the robot translates and rotates, the rotation causes some extra unintended translation
Implementation borrowed from 254: https://github.com/Team254/FRC-2022-Public/blob/main/src/main/java/com/team254/frc2022/subsystems/Drive.java#L325
Discussion: https://www.chiefdelphi.com/t/whitepaper-swerve-drive-skew-and-second-order-kinematics/416964